### PR TITLE
make versionatt in SlowlyChangingDimension optional

### DIFF
--- a/pygrametl/tables.py
+++ b/pygrametl/tables.py
@@ -782,7 +782,7 @@ class SlowlyChangingDimension(Dimension):
        break this assumption.
     """
 
-    def __init__(self, name, key, attributes, lookupatts, orderingatt, 
+    def __init__(self, name, key, attributes, lookupatts, orderingatt=None, 
                  versionatt=None,
                  fromatt=None, fromfinder=None,
                  toatt=None, tofinder=None, minfrom=None, maxto=None,
@@ -801,7 +801,10 @@ class SlowlyChangingDimension(Dimension):
              used for looking up members.
            - orderingatt: the name of the attribute used to identify the newest
              version. The version holding the greatest value is considered to 
-             be the newest.
+             be the newest. If orderingatt is None, versionatt is used. If
+             versionatt is also None, toatt is used and NULL is  considered as 
+             the greatest value. If orderingatt, versionatt,toatt are all None,
+             an error is raised.
            - versionatt: the name of the attribute holding the version number
            - fromatt: the name of the attribute telling from when the version
              becomes valid. Not used if None. Default: None
@@ -884,10 +887,17 @@ class SlowlyChangingDimension(Dimension):
                            rowexpander=None,
                            targetconnection=targetconnection)
 
-        if not orderingatt:
-            raise ValueError('An ordering attribute must be given')
+        if orderingatt is not None:
+            self.orderingatt = orderingatt
+        elif versionatt is not None:
+            self.orderingatt = versionatt
+        elif toatt is not None:
+            self.orderingatt = toatt
+        else:
+            raise ValueError(
+                "If orderingatt is None, either versionatt or toatt must not be None"
+                )
             
-        self.orderingatt = orderingatt
         self.versionatt = versionatt
         self.fromatt = fromatt
         if fromfinder is not None:


### PR DESCRIPTION
As a response to #12, sorry to be so late. 
## changes made
- A new `__init__` argument `orderingatt` is added, which is used later to construct sql queries to find the newest version; `versionatt` become optional, with `None` as default
- `versionatt` in `self.keylookupsql`, `self.keyversionlookupsql` as well as `sql` inside `self.__prefillcaches` are all replaced with `orderingatt`
- Codes that modifies `versionatt` are now wrapped under an if statement, so they won't be executed unless `versionatt` is not `None`, essentially the same as what we do with `fromatt` and `toatt`

## something needs to discuss
- Is the name `orderingatt` clear enough to indicate what it does? Any better name?
- In most cases I can imagine, the most likely candidates of `orderingatt` are `toatt`, `fromatt`, and `versionatt`. So this code somehow implicitly presumes `orderingatt` to be one of the three. If `orderingatt` is not any one of the three, the user is responsible for updating `orderingatt`. Moreover,  in this code, all required for `orderingatt` is that it is not none and is a member of `atttributes`. It is totally legitimate to have something like `(orderingatt=some_exotic_att, versionatt=None, fromatt=None, toatt=None)`. Again that leaves the user the responsibility to do the SCD update. Should this be allowed? Or any further restriction should be imposed?