### PR TITLE
fix bug in scdensure when versionatt is None

### DIFF
--- a/pygrametl/FIFODict.py
+++ b/pygrametl/FIFODict.py
@@ -44,6 +44,7 @@ class FIFODictDeque:
         """Create a FIFODictDeque with the given maximum size.
 
            Arguments:
+               
            - size: Determines the maximum size of the dict.
            - finalizer: If finalizer is given, it must be a callable
              f(key, value). It is then called, when a item is removed due to
@@ -145,6 +146,7 @@ class FIFODictOrderedDict:
         """Create a FIFODictOrderedDict with the given maximum size.
 
            Arguments:
+               
            - size: Determines the maximum size of the dict.
            - finalizer: If finalizer is given, it must be a callable
              f(key, value). It is then called, when a item is removed due to

--- a/pygrametl/JDBCConnectionWrapper.py
+++ b/pygrametl/JDBCConnectionWrapper.py
@@ -67,6 +67,7 @@ class JDBCConnectionWrapper(object):
            ConnectionWrapper is set to be the default ConnectionWrapper.
 
            Arguments:
+               
            - jdbcconn: An open JDBC Connection (not a PEP249 Connection)
            - stmtcachesize: The maximum number of PreparedStatements kept
              open. Default: 20.
@@ -181,6 +182,7 @@ class JDBCConnectionWrapper(object):
         """Execute a statement.
 
            Arguments:
+               
            - stmt: the statement to execute
            - arguments: a mapping with the arguments. Default: None.
            - namemapping: a mapping of names such that if stmt uses %(arg)s
@@ -197,6 +199,7 @@ class JDBCConnectionWrapper(object):
         """Execute a sequence of statements.
 
            Arguments:
+               
            - stmt: the statement to execute
            - params: a sequence of arguments
            - ignored: An ignored argument only present to accept the same
@@ -323,6 +326,7 @@ class BackgroundJDBCConnectionWrapper(object):
         """Create a ConnectionWrapper around the given JDBC connection
 
            Arguments:
+               
            - jdbcconn: An open JDBC Connection (not a PEP249 Connection)
            - stmtcachesize: The maximum number of PreparedStatements kept
              open. Default: 20.
@@ -442,6 +446,7 @@ class BackgroundJDBCConnectionWrapper(object):
         """Execute a statement.
 
            Arguments:
+               
            - stmt: the statement to execute
            - arguments: a mapping with the arguments. Default: None.
            - namemapping: a mapping of names such that if stmt uses %(arg)s
@@ -460,6 +465,7 @@ class BackgroundJDBCConnectionWrapper(object):
         """Execute a sequence of statements.
 
            Arguments:
+               
            - stmt: the statement to execute
            - params: a sequence of arguments
            - ignored: An ignored argument only present to accept the same

--- a/pygrametl/__init__.py
+++ b/pygrametl/__init__.py
@@ -82,6 +82,7 @@ def project(atts, row, renaming={}):
     """Create a new dictionary with a subset of the attributes.
 
        Arguments:
+           
        - atts is a sequence of attributes in row that should be copied to the
          new result row.
        - row is the original dictionary to copy data from.
@@ -105,6 +106,7 @@ def copy(row, **renaming):
     """Create a copy of a dictionary, but allow renamings.
 
        Arguments:
+           
        - row the dictionary to copy
        - **renaming allows renamings to be specified in the form
          newname=oldname meaning that in the result, oldname will be
@@ -276,6 +278,7 @@ def gettimestamp(targetconnection, ymdhmsstr, default=None):
        The returned Timestamp is in the given targetconnection's format.
 
        Arguments:
+           
        - targetconnection: a ConnectionWrapper whose underlying module's
          Timestamp format is used
        - ymdhmsstr: the string to convert
@@ -316,6 +319,7 @@ def setdefaults(row, attributes, defaults=None):
        updated.
 
        Arguments:
+           
        - row is the dictionary to set default values in
        - attributes is either
            A) a sequence of attribute names in which case defaults must
@@ -461,6 +465,7 @@ def datereader(dateattribute, parsingfunction=ymdparser):
        dictionary member from each row and converts it.
 
        Arguments:
+           
        - dateattribute: the attribute the generated function should read
        - parsingfunction: the parsing function that converts the string
          to a datetime.date
@@ -480,6 +485,7 @@ def datetimereader(datetimeattribute, parsingfunction=ymdhmsparser):
        dictionary member from each row and converts it.
 
        Arguments:
+           
        - datetimeattribute: the attribute the generated function should read
        - parsingfunction: the parsing function that converts the string
          to a datetime.datetime
@@ -499,6 +505,7 @@ def datespan(fromdate, todate, fromdateincl=True, todateincl=True,
     """Return a generator yielding dicts for all dates in an interval.
 
        Arguments:
+           
        - fromdate: The lower bound for the date interval. Should be a
          datetime.date or a YYYY-MM-DD formatted string.
        - todate: The upper bound for the date interval. Should be a
@@ -610,6 +617,7 @@ class ConnectionWrapper(object):
            ConnectionWrapper is set as the default.
 
            Arguments:
+               
            - connection: An open PEP 249 connection to the database
            - stmtcachesize: A number deciding how many translated statements to
              cache. A statement needs to be translated when the connection
@@ -648,6 +656,7 @@ class ConnectionWrapper(object):
         """Execute a statement.
 
            Arguments:
+               
            - stmt: the statement to execute
            - arguments: a mapping with the arguments (default: None)
            - namemapping: a mapping of names such that if stmt uses %(arg)s

--- a/pygrametl/datasources.py
+++ b/pygrametl/datasources.py
@@ -67,6 +67,7 @@ class TypedCSVSource(DictReader):
     def __init__(self, csvfile, casts, fieldnames=None, restkey=None,
                  restval=None, dialect='excel', *args, **kwds):
         """Arguments:
+            
            - f: An iterable object such as as file. Passed on to
              csv.DictReader
            - casts: A dict mapping from attribute names to functions to apply
@@ -109,6 +110,7 @@ class SQLSource(object):
     def __init__(self, connection, query, names=(), initsql=None,
                  cursorarg=None, parameters=None):
         """Arguments:
+            
            - connection: the PEP 249 connection to use. NOT a
              ConnectionWrapper!
            - query: the query that generates the result
@@ -173,6 +175,7 @@ class ProcessSource(object):
 
     def __init__(self, source, batchsize=500, queuesize=20):
         """Arguments:
+            
            - source: the source to iterate
            - batchsize: the number of rows passed from the worker process each
              time it passes on a batch of rows. Must be positive. Default: 500
@@ -232,6 +235,7 @@ class HashJoiningSource(object):
 
     def __init__(self, src1, key1, src2, key2):
         """Arguments:
+            
            - src1: the first source. This source is iterated row by row.
            - key1: the attribute of the first source to use in the join
            - src2: the second source. The rows of this source are all loaded
@@ -271,6 +275,7 @@ class MergeJoiningSource(object):
 
     def __init__(self, src1, key1, src2, key2):
         """Arguments:
+            
         - src1: a data source
         - key1: the attribute to use from src1
         - src2: a data source
@@ -337,6 +342,7 @@ class TransformingSource(object):
 
     def __init__(self, source, *transformations):
         """Arguments:
+            
         - source: a data source
         - *transformations: the transformations to apply. Must be callables
           of the form func(row) where row is a dict. Will be applied in the
@@ -359,6 +365,7 @@ class CrossTabbingSource(object):
     def __init__(self, source, rowvaluesatt, colvaluesatt, values,
                  aggregator=None, nonevalue=0, sortrows=False):
         """Arguments:
+            
         - source: the data source to pull data from
         - rowvaluesatt: the name of the attribute that holds the values that
           appear as rows in the result
@@ -410,6 +417,7 @@ class FilteringSource(object):
 
     def __init__(self, source, filter=bool):
         """Arguments:
+            
            - source: the source to filter
            - filter: a callable f(row). If the result is a True value,
              the row is passed on. If not, the row is discarded.
@@ -434,6 +442,7 @@ class UnionSource(object):
 
     def __init__(self, *sources):
         """Arguments:
+            
            - *sources: The sources to union in the order they should be used.
         """
         self.__sources = sources
@@ -450,6 +459,7 @@ class RoundRobinSource(object):
 
     def __init__(self, sources, batchsize=500):
         """Arguments:
+            
            - sources: a sequence of data sources
            - batchsize: the amount of rows to read from a data source before
              going to the next data source. Must be positive (to empty a source
@@ -492,6 +502,7 @@ class DynamicForEachSource(object):
 
     def __init__(self, seq, callee):
         """Arguments:
+            
            - seq: a sequence with the elements for each of which a unique
              source must be created. the elements are given (one by one) to
              callee.

--- a/pygrametl/parallel.py
+++ b/pygrametl/parallel.py
@@ -201,6 +201,7 @@ def splitpoint(*arg, **kwargs):
            all of keyword arguments above are given.`
 
        Keyword arguments:
+           
        - output: If given, it should be a queue-like object (offering the
          .put(obj) method). The annotated function's results will then be put
          in the output
@@ -452,6 +453,7 @@ def createflow(*functions, **options):
        memory .
 
        Arguments:
+           
        - *functions: A sequence of functions of sequences of functions.
          Each element in the sequence will be executed in a separate process.
          For example, the argument (f1, (f2, f3), f4) leads to that
@@ -524,6 +526,7 @@ class FutureResult(object):
 
     def __init__(self, creator, id):
         """Arguments:
+            
         - creator: a value that identifies the creator of the FutureResult.
           Use a primitive value.
         - id: a unique identifier for the FutureResult.
@@ -820,6 +823,7 @@ class SharedConnectionWrapperClient(object):
         """Execute a statement.
 
            Arguments:
+               
            - stmt: the statement to execute
            - arguments: a mapping with the arguments (default: None)
            - namemapping: a mapping of names such that if stmt uses %(arg)s
@@ -1022,6 +1026,7 @@ def shareconnectionwrapper(targetconnection, maxclients=10, userfuncs=()):
     .. Note:: The SharedConnectionWrapper must be copied using .copy().
 
     Arguments:
+        
     - targetconnection: a pygrametl ConnectionWrapper
     - maxclients: the maximum number of concurrent clients. Default: 10
     - userfuncs: a sequence of functions to add to the shared
@@ -1081,6 +1086,7 @@ def getsharedsequencefactory(startvalue, intervallen=5000):
         threads.
 
         Arguments:
+            
         - startvalue: The first value to return. If None, 0 is assumed.
         - intervallen: The amount of numbers that a single g from above
           can return before synchronization is needed to get a new amount.

--- a/pygrametl/steps.py
+++ b/pygrametl/steps.py
@@ -53,6 +53,7 @@ class Step(object):
 
     def __init__(self, worker=None, next=None, name=None):
         """Arguments:
+            
            - worker: A function f(row) that performs the Step's operation.
              If None, self.defaultworker is used. Default: None
            - next: The default next step to use. This should be 1) an instance
@@ -140,6 +141,7 @@ class SourceStep(Step):
 
     def __init__(self, source, next=None, name=None):
         """Arguments:
+            
            - source: The data source. Must be iterable.
            - next: The default next step to use. This should be 1) an instance
              of a Step, 2) the name of a Step, or 3) None.
@@ -166,6 +168,7 @@ class MappingStep(Step):
 
     def __init__(self, targets, requiretargets=True, next=None, name=None):
         """Arguments:
+            
            - targets: A sequence of (name, function) pairs. For each element,
              row[name] is set to function(row[name]) for each row given to the
              step.
@@ -202,6 +205,7 @@ class ValueMappingStep(Step):
     def __init__(self, outputatt, inputatt, mapping, requireinput=True,
                  defaultvalue=None, next=None, name=None):
         """Arguments:
+            
            - outputatt: The attribute to write the mapped value to in each row.
            - inputatt: The attribute to map.
            - mapping: A dict with the mapping itself.
@@ -244,6 +248,7 @@ class PrintStep(Step):
 
     def __init__(self, next=None, name=None):
         """Arguments:
+            
            - next: The default next step to use. This should be 1) an instance
              of a Step, 2) the name of a Step, or 3) None.
              If if is a name, the next step will be looked up dynamically
@@ -266,6 +271,7 @@ class DimensionStep(Step):
 
     def __init__(self, dimension, keyfield=None, next=None, name=None):
         """Arguments:
+            
            - dimension: the Dimension object to call ensure on.
            - keyfield: the name of the attribute that in each row is set to
              hold the key value for the dimension member
@@ -295,6 +301,7 @@ class SCDimensionStep(Step):
 
     def __init__(self, dimension, next=None, name=None):
         """Arguments:
+            
            - dimension: the Dimension object to call ensure on.
            - keyfield: the name of the attribute that in each row is set to
              hold the key value for the dimension member
@@ -321,6 +328,7 @@ class RenamingFromToStep(Step):
 
     def __init__(self, renaming, next=None, name=None):
         """Arguments:
+            
            - name: A name for the Step instance. This is used when another
              Step (implicitly or explicitly) passes on rows. If two instanes
              have the same name, the name is mapped to the instance that was
@@ -358,6 +366,7 @@ class GarbageStep(Step):
 
     def __init__(self, name=None):
         """Arguments:
+            
            - name: A name for the Step instance. This is used when another
              Step (implicitly or explicitly) passes on rows. If two instanes
              have the same name, the name is mapped to the instance that was
@@ -375,6 +384,7 @@ class ConditionalStep(Step):
 
     def __init__(self, condition, whentrue, whenfalse=None, name=None):
         """Arguments:
+            
            - condition: A function f(row) that is evaluated for each row.
            - whentrue: The next step to use if the condition evaluates to a
              true value. This argument  should be 1) an instance of a Step,
@@ -410,6 +420,7 @@ class CopyStep(Step):
 
     def __init__(self, originaldest, copydest, deepcopy=False, name=None):
         """Arguments:
+            
            - originaldest: The Step each given row is passed on to.
              This argument  should be 1) an instance of a Step,
              2) the name of a Step, or 3) None.

--- a/pygrametl/tables.py
+++ b/pygrametl/tables.py
@@ -81,6 +81,7 @@ def definequote(quotechar):
 
     
        Arguments:
+           
        - quotechar: If None, do not wrap identifier. If a string, prepend and
          append quotechar to identifier. If a tuple of two strings, prepend with
          first element and append with last.
@@ -105,6 +106,7 @@ class Dimension(object):
                  idfinder=None, defaultidvalue=None, rowexpander=None,
                  targetconnection=None):
         """Arguments:
+            
            - name: the name of the dimension table in the DW
            - key: the name of the primary key in the DW
            - attributes: a sequence of the attribute names in the dimension
@@ -196,6 +198,7 @@ class Dimension(object):
         """Find the key for the row with the given values.
 
            Arguments:
+               
            - row: a dict which must contain at least the lookup attributes
            - namemapping: an optional namemapping (see module's documentation)
         """
@@ -245,6 +248,7 @@ class Dimension(object):
         """Return a list of all rows with values identical to the given.
 
            Arguments:
+               
            - values: a dict which must hold a subset of the tables attributes.
              All rows that have identical values for all attributes in this
              dict are returned.
@@ -279,6 +283,7 @@ class Dimension(object):
         """Update a single row in the dimension table.
 
            Arguments:
+               
            - row: a dict which must contain the key for the dimension.
              The row with this key value is updated such that it takes
              the value of row[att] for each attribute att which is also in
@@ -319,6 +324,7 @@ class Dimension(object):
            instance, this rowexpander is called before the insert takes place.
 
            Arguments:
+               
            - row: the row to lookup or insert. Must contain the lookup
              attributes. Key is not required to be present but will be added
              using idfinder if missing.
@@ -336,6 +342,7 @@ class Dimension(object):
         """Insert the given row. Return the new key value.
 
            Arguments:
+               
            - row: the row to insert. The dict is not updated. It must contain
              all attributes, and is allowed to contain more attributes than
              that. Key is not required to be present but will be added using
@@ -389,6 +396,7 @@ class CachedDimension(Dimension):
                  cacheoninsert=True, usefetchfirst=False,
                  targetconnection=None):
         """Arguments:
+            
            - name: the name of the dimension table in the DW
            - key: the name of the primary key in the DW
            - attributes: a sequence of the attribute names in the dimension
@@ -588,6 +596,7 @@ class TypeOneSlowlyChangingDimension(CachedDimension):
                  usefetchfirst=False, cachefullrows=False,
                  targetconnection=None):
         """Arguments:
+            
            - name: the name of the dimension table in the DW
            - key: the name of the primary key in the DW
            - attributes: a sequence of the attribute names in the dimension
@@ -673,6 +682,7 @@ class TypeOneSlowlyChangingDimension(CachedDimension):
            .. Note:: Has side-effects on the given row.
 
            Arguments:
+               
            - row: a dict containing the attributes for the table. It must
              contain all attributes if it is the first version of the row to be
              inserted, updates of existing rows need only contain lookupatts
@@ -790,6 +800,7 @@ class SlowlyChangingDimension(Dimension):
                  type1atts=(), cachesize=10000, prefill=False, idfinder=None,
                  usefetchfirst=False, useorderby=True, targetconnection=None):
         """Arguments:
+            
            - name: the name of the dimension table in the DW
            - key: the name of the primary key in the DW
            - attributes: a sequence of the attribute names in the dimension
@@ -1006,6 +1017,7 @@ class SlowlyChangingDimension(Dimension):
         """Find the key for the newest version with the given values.
 
            Arguments:
+               
            - row: a dict which must contain at least the lookup attributes
            - namemapping: an optional namemapping (see module's documentation)
         """
@@ -1025,6 +1037,7 @@ class SlowlyChangingDimension(Dimension):
         """Find the key for the newest version of the row with the given values.
 
            Arguments:
+               
            - row: a dict which must contain at least the lookup attributes
            - namemapping: an optional namemapping (see module's documentation)
         """
@@ -1059,6 +1072,7 @@ class SlowlyChangingDimension(Dimension):
            .. Note:: Has side-effects on the given row.
 
            Arguments:
+               
            - row: a dict containing the attributes for the member.
              key, versionatt, fromatt, and toatt are not required to be
              present but will be added (if defined).
@@ -1067,6 +1081,8 @@ class SlowlyChangingDimension(Dimension):
         key = (namemapping.get(self.key) or self.key)
         if self.versionatt:
             versionatt = (namemapping.get(self.versionatt) or self.versionatt)
+        else:
+            versionatt = None
         if self.fromatt:  # this protects us against None in namemapping.
             fromatt = (namemapping.get(self.fromatt) or self.fromatt)
         else:
@@ -1290,6 +1306,7 @@ class SnowflakedDimension(object):
 
     def __init__(self, references, expectboguskeyvalues=False):
         """Arguments:
+            
            - references: a sequence of pairs of Dimension objects
              [(a1,a2), (b1,b2), ...] meaning that a1 has a foreign key to a2
              etc. a2 may itself be a sequence of Dimensions:
@@ -1394,6 +1411,7 @@ class SnowflakedDimension(object):
         """Find the key for the row with the given values.
 
            Arguments:
+               
            - row: a dict which must contain at least the lookup attributes
              which all must come from the root (the table closest to the
              fact table).
@@ -1419,6 +1437,7 @@ class SnowflakedDimension(object):
            a row where all values (including the key) are None.
 
            Arguments:
+               
            - keyvalue: the key value of the row to lookup
            - fullrow: a flag deciding if the full row (with data from
              all tables in the snowflake) should be returned. If False,
@@ -1447,6 +1466,7 @@ class SnowflakedDimension(object):
         """Return a list of all rows with values identical to the given.
 
            Arguments:
+               
            - values: a dict which must hold a subset of the tables attributes.
              All rows that have identical values for all attributes in this
              dict are returned.
@@ -1499,6 +1519,7 @@ class SnowflakedDimension(object):
            directly on the Dimensions that should be updated.
 
            Arguments:
+               
            - row: a dict. If the key of a participating dimension D is in the
              dict, D.update(...) is invoked.
            - namemapping: an optional namemapping (see module's documentation)
@@ -1533,6 +1554,7 @@ class SnowflakedDimension(object):
            afterwards.
 
            Arguments:
+               
            - row: the row to lookup or insert. Must contain the lookup
              attributes. Key is not required to be present but will be added
              using idfinder if missing.
@@ -1553,6 +1575,7 @@ class SnowflakedDimension(object):
            afterwards.
 
            Arguments:
+               
            - row: the row to lookup or insert. Must contain the lookup
              attributes. Key is not required to be present but will be added
              using idfinder if missing.
@@ -1631,6 +1654,7 @@ class SnowflakedDimension(object):
            .. Note:: Has side-effects on the given row.
 
            Arguments:
+               
            - row: a dict containing the attributes for the member. Key is not
              required to be present but will be added using idfinder if
              missing.
@@ -1694,6 +1718,7 @@ class FactTable(object):
         """Insert a fact into the fact table.
 
            Arguments:
+               
            - row: a dict at least containing values for the keys and measures.
            - namemapping: an optional namemapping (see module's documentation)
         """
@@ -1724,6 +1749,7 @@ class FactTable(object):
            Return None if no fact is found.
 
            Arguments:
+               
            - keyvalues: a dict at least containing values for all keys
            - namemapping: an optional namemapping (see module's documentation)
         """
@@ -1748,6 +1774,7 @@ class FactTable(object):
            was already present in the fact table; False if not.
 
            Arguments:
+               
            - row: a dict at least containing the attributes of the fact table
            - compare: a flag deciding if measure vales from a fact that was
              looked up are compared to those in the given row. If True and
@@ -1785,6 +1812,7 @@ class BatchFactTable(FactTable):
     def __init__(self, name, keyrefs, measures=(), batchsize=10000,
                  targetconnection=None):
         """Arguments:
+            
            - name: the name of the fact table in the DW
            - keyrefs: a sequence of attribute names that constitute the
              primary key of the fact tables (i.e., the dimension references)
@@ -1834,6 +1862,7 @@ class _BaseBulkloadable(object):
                  strconverter=pygrametl.getdbfriendlystr, encoding=None, 
                  dependson=()):
         r"""Arguments:
+            
            - name: the name of the table in the DW
            - atts: a sequence of the bulkloadable tables' attribute names
            - bulkloader: A method
@@ -1925,6 +1954,7 @@ class _BaseBulkloadable(object):
         """Insert (eventually) a row into the table.
 
            Arguments:
+               
            - row: a dict at least containing values for each of the tables'
              attributes.
            - namemapping: an optional namemapping (see module's documentation)
@@ -1991,6 +2021,7 @@ class BulkFactTable(_BaseBulkloadable):
                  strconverter=pygrametl.getdbfriendlystr,
                  encoding=None, dependson=()):
         r"""Arguments:
+            
            - name: the name of the fact table in the DW
            - keyrefs: a sequence of attribute names that constitute the
              primary key of the fact tables (i.e., the dimension references)
@@ -2091,6 +2122,7 @@ class BulkDimension(_BaseBulkloadable, CachedDimension):
                  usefilename=False, strconverter=pygrametl.getdbfriendlystr,
                  encoding=None, dependson=(), targetconnection=None):
         r"""Arguments:
+            
            - name: the name of the dimension table in the DW
            - key: the name of the primary key in the DW
            - attributes: a sequence of the attribute names in the dimension
@@ -2221,6 +2253,7 @@ class BulkDimension(_BaseBulkloadable, CachedDimension):
         """Insert the given row. Return the new key value.
 
            Arguments:
+               
            - row: the row to insert. The dict is not updated. It must contain
              all attributes, and is allowed to contain more attributes than
              that. Key is not required to be present but will be added using
@@ -2281,6 +2314,7 @@ class CachedBulkDimension(_BaseBulkloadable, CachedDimension):
                  usefilename=False, strconverter=pygrametl.getdbfriendlystr,
                  encoding=None, dependson=(), targetconnection=None):
         r"""Arguments:
+            
            - name: the name of the dimension table in the DW
            - key: the name of the primary key in the DW
            - attributes: a sequence of the attribute names in the dimension
@@ -2431,6 +2465,7 @@ class CachedBulkDimension(_BaseBulkloadable, CachedDimension):
         """Insert the given row. Return the new key value.
 
            Arguments:
+               
            - row: the row to insert. The dict is not updated. It must contain
              all attributes, and is allowed to contain more attributes than
              that. Key is not required to be present but will be added using
@@ -2475,6 +2510,7 @@ class SubprocessFactTable(object):
                  strconverter=pygrametl.getdbfriendlystr,
                  buffersize=16384):
         r"""Arguments:
+            
            - keyrefs: a sequence of attribute names that constitute the
              primary key of the fact table (i.e., the dimension references)
            - measures: a possibly empty sequence of measure names. Default: ()
@@ -2520,6 +2556,7 @@ class SubprocessFactTable(object):
         """Insert a fact into the fact table.
 
            Arguments:
+               
            - row: a dict at least containing values for the keys and measures.
            - namemapping: an optional namemapping (see module's documentation)
         """
@@ -2560,6 +2597,7 @@ class DecoupledDimension(pygrametl.parallel.Decoupled):
     def __init__(self, dim, returnvalues=True, consumes=(), attstoconsume=(),
                  batchsize=500, queuesize=200):
         """Arguments:
+            
            - dim: the Dimension object to use in a separate process
            - returnvalues: decides if return values from method calls on dim
              should be kept such that they can be fetched by the caller or
@@ -2645,6 +2683,7 @@ class DecoupledFactTable(pygrametl.parallel.Decoupled):
     def __init__(self, facttbl, returnvalues=True, consumes=(),
                  attstoconsume=(), batchsize=500, queuesize=200):
         """Arguments:
+            
            - facttbl: the FactTable object to use in a separate process
            - returnvalues: decides if return values from method calls on
              facttbl should be kept such that they can be fetched by the caller
@@ -2767,6 +2806,7 @@ class DimensionPartitioner(BasePartitioner):
 
     def __init__(self, parts, getbyvalsfromall=False, partitioner=None):
         """Arguments:
+            
            - parts: a sequence of Dimension objects.
            - getbyvalsfromall: determines if getbyvals should be answered by
              means of all parts (when getbyvalsfromall = True) or only the
@@ -2873,6 +2913,7 @@ class FactTablePartitioner(BasePartitioner):
     def __init__(self, parts, partitioner=None):
         """
         Arguments:
+            
         - parts: a sequence of FactTable objects.
         - partitioner: None or a callable p(dict) -> int where the argument
           is a dict mapping from the names of the keyrefs to the values of


### PR DESCRIPTION
In last commit, when calling `scdensure`, local variable `versionatt` is not defined if `self.versionatt` is None, resulting in an "referenced before assignment" error in the following code. This patch adds a fallback case to prevent that.
```Python
         if self.versionatt:
             versionatt = (namemapping.get(self.versionatt) or self.versionatt)
        else:
             versionatt = None
```

Also, I try to prettify arguments list in the docstrings. In my local environment, I use Spyder as an IDE. I find that arugments list in the doc messed up. Some items join to the preceding paragraph instead of being a separate item.
![image](https://user-images.githubusercontent.com/17619612/27851145-8f8ac536-618b-11e7-93ea-affaa2414169.png)

I checked [the document of reStructuredText](http://docutils.sourceforge.net/docs/user/rst/quickref.html#bullet-lists) and learned that
>Note that a blank line is required before the first item and after the last, but is optional between items.

I am no expert in documentation tools. I am not sure whether it is a problem in my local environment or a problem of the docstrings. But anyway I added a blank line in all arguments list in case if needed.