### PR TITLE
Added the MappingSource datasource

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Unreleased
 ----------
 **Added**
+  ``MappingSource`` a new class, that given a data source and a dictionary of
+  columns to callables, maps the callables over each element of the specified
+  column before returning the row.
+
 **Changed**
   ``SlowlyChangingDimension`` improved to make ``versionatt`` optional. 
   (GitHub issue #12. Thanks to HereticSK) 

--- a/docs/examples/datasources.rst
+++ b/docs/examples/datasources.rst
@@ -241,6 +241,25 @@ row should be passed on.
 In the above example, a very simple filter is used, which filters out rows
 where the value of the *location* attribute is not *Aalborg*.
 
+MappingSource
+------------------
+The class :class:`.MapppingSource` can be used to apply functions to the
+columns of a source. The class can be supplied with a dictionary mapping columns
+to callable functions of the form ``f(val)``, which will be applied to columns
+in an undefined order.
+
+.. code-block:: python
+
+    import pygrametl
+    from pygrametl.datasources import CSVSource, MappingSource
+
+    sales = CSVSource(csvfile=open('sales.csv', 'r', 16384), delimiter=',')
+
+    sales_transformed = MapppingSource(source=sales, {'price':int})
+
+In the above example, a function is used to cast all values of the column price
+to integer while rows are read from a .csv.
+
 TransformingSource
 ------------------
 The class :class:`.TransformingSource` can be used to apply functions to the

--- a/pygrametl/datasources.py
+++ b/pygrametl/datasources.py
@@ -50,12 +50,12 @@ except NameError:
 
 __author__ = "Christian Thomsen"
 __maintainer__ = "Christian Thomsen"
-__version__ = '2.5.0'
+__version__ = '2.5.1'
 __all__ = ['CSVSource', 'TypedCSVSource', 'SQLSource', 'JoiningSource',
            'HashJoiningSource', 'MergeJoiningSource', 'BackgroundSource',
-           'ProcessSource', 'TransformingSource', 'UnionSource',
-           'CrossTabbingSource', 'FilteringSource', 'DynamicForEachSource',
-           'RoundRobinSource']
+           'ProcessSource', 'MappingSource', 'TransformingSource',
+           'UnionSource', 'CrossTabbingSource', 'FilteringSource',
+           'DynamicForEachSource', 'RoundRobinSource']
 
 
 CSVSource = DictReader
@@ -334,6 +334,32 @@ class MergeJoiningSource(object):
             else:
                 self.__next = row
                 return res
+
+
+class MappingSource(object):
+    """A class for iterating a source and applying a function to each column."""
+
+    def __init__(self, source, callables):
+        """Arguments:
+
+           - source: A data source
+           - callables: A dict mapping from attribute names to functions to
+             apply to these names, e.g. type casting {'id':int, 'salary':float}
+        """
+        if not type(callables) == dict:
+            raise TypeError("The callables argument must be a dict")
+        for v in callables.values():
+            if not callable(v):
+                raise TypeError("The values in callables must be callable")
+
+        self._source = source
+        self._callables = callables
+
+    def __iter__(self):
+        for row in self._source:
+            for (att, func) in self._callables.items():
+                row[att] = func(row[att])
+                yield row
 
 
 class TransformingSource(object):


### PR DESCRIPTION
MappingSource allows a callable to be executed for all elements of a column,
for example type casting can be performed by simple passing in {'Price':Int}.