### PR TITLE
Added PandasSource, a datasource for DataFrames

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Unreleased
 ----------
 **Added**
+  ``PandasSource`` a new class, that given a Pandas DataFrame function as a
+  data source. Each row of the DataFrame is returned as a dict that can be
+  loaded into a data warehouse using pygrametl.tables.
+
   ``MappingSource`` a new class, that given a data source and a dictionary of
   columns to callables, maps the callables over each element of the specified
   column before returning the row.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Unreleased
 ----------
 **Added**
-  ``PandasSource`` a new class, that given a Pandas DataFrame function as a
+  ``PandasSource`` a new class, that given a Pandas DataFrame acts as a
   data source. Each row of the DataFrame is returned as a dict that can be
   loaded into a data warehouse using pygrametl.tables.
 

--- a/docs/examples/datasources.rst
+++ b/docs/examples/datasources.rst
@@ -113,6 +113,43 @@ dictionary is passed as the second providing information about what type each
 column should be cast to. A cast is not performed for the name column as
 :class:`.TypedCSVSource` uses strings as the default.
 
+PandasSource
+-------------
+The class :class:`.PandasSource` is a data source that return each row of a
+Pandas DataFrame as a dictionary. The class is fairly simple, and is implemented
+as a wrapper around existing functionality provided by `DataFrames
+<https://pandas.pydata.org/pandas-docs/stable/api.html#dataframe>`_. An example
+of the how to use this class can be seen below. In this example some data is
+loaded from a spreadsheet, then transformed using a Pandas DataFrame, and last
+converted to an iterator of dictionaries for use with pygrametl:
+
+.. code-block:: python
+
+    import pandas
+    from pygrametl.datasources import PandasSource
+
+    # For this example the revenue of a store is kept in a spreadsheet, so
+    # we use Pandas to load the data into a DataFrame so we can manipulate it.
+    df = pandas.read_excel('revenue.xls')
+
+    # After constructing the DataFrame, the data can be easily transformed using
+    # the transformation and higher-order functions implemented as part of the
+    # DataFrame. In this example the price of each book is converted from Danish
+    # kroner (DKK) to euros.
+    df['price'] = df['price'].apply(lambda p : float(p) / 7.46)
+
+    # Afterwards, to load the DataFrame into the data warehouse, a
+    # PandasSource is constructed which returns each row from the DataFrame as a
+    # dictionary suitable for pygrametl to load.
+    ps = PandasSource(df)
+
+In the above example, a Pandas DataFrame is created from a spreadsheet
+containing revenue from some form of sales. Afterwards, the data of one column
+is transformed using one of the higher-order functions build into the Pandas
+library. Last, so the data can be loaded into a data warehouse using pygrametl,
+a :class:`.PandasSource` is created with the DataFrame as argument, making the
+rows of the DataFrame accessible as an iterator of dict.
+
 MergeJoiningSource
 ------------------
 In addition to the aforementioned data sources, pygrametl also includes a

--- a/docs/examples/datasources.rst
+++ b/docs/examples/datasources.rst
@@ -115,7 +115,7 @@ column should be cast to. A cast is not performed for the name column as
 
 PandasSource
 -------------
-The class :class:`.PandasSource` is a data source that return each row of a
+The class :class:`.PandasSource` is a data source that returns each row of a
 Pandas DataFrame as a dictionary. The class is fairly simple, and is implemented
 as a wrapper around existing functionality provided by `DataFrames
 <https://pandas.pydata.org/pandas-docs/stable/api.html#dataframe>`_. An example

--- a/pygrametl/datasources.py
+++ b/pygrametl/datasources.py
@@ -50,12 +50,12 @@ except NameError:
 
 __author__ = "Christian Thomsen"
 __maintainer__ = "Christian Thomsen"
-__version__ = '2.5.1'
-__all__ = ['CSVSource', 'TypedCSVSource', 'SQLSource', 'JoiningSource',
-           'HashJoiningSource', 'MergeJoiningSource', 'BackgroundSource',
-           'ProcessSource', 'MappingSource', 'TransformingSource',
-           'UnionSource', 'CrossTabbingSource', 'FilteringSource',
-           'DynamicForEachSource', 'RoundRobinSource']
+__version__ = '2.5.2'
+__all__ = ['CSVSource', 'TypedCSVSource', 'SQLSource', 'PandasSource',
+           'JoiningSource', 'HashJoiningSource', 'MergeJoiningSource',
+           'BackgroundSource', 'ProcessSource', 'MappingSource',
+           'TransformingSource', 'UnionSource', 'CrossTabbingSource',
+           'FilteringSource', 'DynamicForEachSource', 'RoundRobinSource']
 
 
 CSVSource = DictReader
@@ -167,6 +167,22 @@ class SQLSource(object):
                 self.cursor.close()
             except Exception:
                 pass
+
+class PandasSource(object):
+
+    """A source for iterating a Pandas DataFrame and cast each row to a dict."""
+
+    def __init__(self, dataFrame):
+        """Arguments:
+
+           - dataFrame: A Pandas DataFrame
+        """
+        self._dataFrame = dataFrame
+
+    def __iter__(self):
+        for (_, series) in self._dataFrame.iterrows():
+            row = series.to_dict()
+            yield row
 
 
 class ProcessSource(object):


### PR DESCRIPTION
The PandasSource can be used to convert a Pandas DataFrame to an iterator of
dict, and as a result, possible to load into a data warehouse using pygrametl.