### PR TITLE
Fix #19 by adding batch loading using INSERT INTO

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Version 2.7 (unreleased)
   ``AccumulatingSnapshotFactTable`` a new class supporting accumulating
   snapshot fact tables where facts can be updated as a process progresses.
 
+  ``BatchFactTable.__init__`` now optionally takes the argument ``usevalues``.
+  When this argument is ``True`` (the default is ``False``), batches are loaded
+  using an ``INSERT INTO name VALUES`` statement instead of ``executemany()``.
+  (GitHub issue #19).
+
   ``closecurrent`` method to ``SlowlyChangingDimension`` to make it possible
   to set an end date for the most current version without adding a new
   version.


### PR DESCRIPTION
In a small benchmark, loading 50 million auto-generated rows into PostgreSQL on a laptop using psycopg2, ``BatchFactTable.__insertvalues`` (17 Minutes) was approximately four time faster than ``BatchFactTable.__insertexecutemany`` (70 Minutes).