### PR TITLE
Corrected 2 errors in datespan function 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,7 +48,11 @@ Version 2.7 (unreleased)
   Wrong use of paramstyle in ``ConnectionWrapper.executemany`` fixed.
 
   A call to an incorrect method in ``aggregators.Avg.finish()``.
-
+  
+  The ``datepan()`` function now checks whether ``fromdate`` and ``todate`` are 
+  strings before calling ``.split()``. In addition, the function now uses ``dict.items()``
+  instead of ``dict.iteritems()`` which is not supported in Python 3.
+  
 Version 2.6
 -----------
 **Added**

--- a/pygrametl/__init__.py
+++ b/pygrametl/__init__.py
@@ -531,11 +531,13 @@ def datespan(fromdate, todate, fromdateincl=True, todateincl=True,
                 "fromdate and today must be datetime.dates or " +
                 "YYYY-MM-DD formatted strings")
 
-    (year, month, day) = fromdate.split('-')
-    fromdate = date(int(year), int(month), int(day))
+    if type(fromdate) in _stringtypes:
+        (year, month, day) = fromdate.split('-')
+        fromdate = date(int(year), int(month), int(day))
 
-    (year, month, day) = todate.split('-')
-    todate = date(int(year), int(month), int(day))
+    if type(todate) in _stringtypes:
+        (year, month, day) = todate.split('-')
+        todate = date(int(year), int(month), int(day))
 
     start = fromdate.toordinal()
     if not fromdateincl:
@@ -549,9 +551,9 @@ def datespan(fromdate, todate, fromdateincl=True, todateincl=True,
         d = date.fromordinal(i)
         res = {}
         res[key] = int(d.strftime('%Y%m%d'))
-        for (att, attformat) in strings.iteritems():
+        for (att, attformat) in strings.items():
             res[att] = d.strftime(attformat)
-        for (att, attformat) in ints.iteritems():
+        for (att, attformat) in ints.items():
             res[att] = int(d.strftime(attformat))
         if expander is not None:
             expander(d, res)


### PR DESCRIPTION
Error 1: The function did not check whether 'fromdate' and 'todate' are strings before calling .split
Error 2: The function used dict.iteritems() which is not supported in Python 3. 