### PR TITLE
Corrected errors in SlowlyChangingDimension and  SnowflakedDimension

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,10 @@ Version 2.7
   strings before calling ``.split()``. In addition, the function now uses
   ``dict.items()`` instead of ``dict.iteritems()`` which is not supported in
   Python 3.
+  
+  Wrong use of ``quotelist()`` changed to ``quote()`` in ``SlowlyChangingDimension``.
+  
+  Missing key value of root when calling ``getbykey`` of ``SnowflakedDimension`` fixed.
 
 Version 2.6
 -----------

--- a/pygrametl/tables.py
+++ b/pygrametl/tables.py
@@ -980,9 +980,9 @@ class SlowlyChangingDimension(Dimension):
             lookupattlist = ', '.join(self.lookupatts)
             newestversions = ('SELECT %s, MAX(%s) AS %s FROM %s GROUP BY %s' %
                               (self.quote(lookupattlist),
-                               self.quotelist(self.orderingatt),
-                               self.quotelist(self.orderingatt), self.name,
-                               self.quotelist(lookupattlist)))
+                               self.quote(self.orderingatt),
+                               self.quote(self.orderingatt), self.name,
+                               self.quote(lookupattlist)))
             joincond = ' AND '.join(['A.%s = B.%s' % (self.quote(att), att)
                                      for att in [l for l in self.lookupatts] +
                                      [self.orderingatt]
@@ -1407,7 +1407,7 @@ class SnowflakedDimension(object):
 
         self.keylookupsql = self.root.keylookupsql
 
-        self.allnames = []
+        self.allnames = [self.root.key]
         for dim in dims:
             for att in dim.attributes:
                 self.allnames.append(att)


### PR DESCRIPTION
Error 1: The use of ._quotelist_ instead of ._quote_ in _SlowlyChangingDimension_ resulted in incorrect column names 
Error 2: The return value of a call to _getbyvals_ in _SnowflakedDimension_ did not include the key value of the root 