### PR TITLE
Prevent contamination of input dictionary

### DIFF
--- a/pygrametl/tables.py
+++ b/pygrametl/tables.py
@@ -692,6 +692,7 @@ class TypeOneSlowlyChangingDimension(CachedDimension):
         # only contains "lookupatts" which "scdensure" is prohibited from
         # changing
 
+        row = row.copy()
         keyval = self.lookup(row, namemapping)
         key = (namemapping.get(self.key) or self.key)
         if keyval is None:
@@ -1076,6 +1077,7 @@ class SlowlyChangingDimension(Dimension):
              present but will be added (if defined).
            - namemapping: an optional namemapping (see module's documentation)
         """
+        row = row.copy()
         key = (namemapping.get(self.key) or self.key)
         if self.versionatt:
             versionatt = (namemapping.get(self.versionatt) or self.versionatt)


### PR DESCRIPTION
I noticed that scdensure for a SCD table manipulates the input row object. For example, the key attribute is added to the dictionary. This could lead to UNIQUE constraint conflicts when scdensure is called for another table where the key attribute names are the same, because the key attribute is preserved even though a new one should be assigned. If the user really wants the key inside the dict, he can assign it himself from the return value of the scdensure function: `row[keyatt] = dimTable.scdensure(row)`