### PR TITLE
Added missing BulkFactTable attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 tests
 docs/_build
+__pycache__/
+*.egg-info/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
-Version 2.7.1 (unreleased)
------------
+Unreleased
+----------
 **Fixed**
 ``BulkFactTable.__init__`` now sets the attributes ``keyrefs``, ``measures``, and ``all``.
 These attributes are required by the ``FactTablePartitioner``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-Version 2.7.1
+Version 2.7.1 (unreleased)
 -----------
 **Fixed**
 ``BulkFactTable.__init__`` now sets the attributes ``keyrefs``, ``measures``, and ``all``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+Version 2.7.1
+-----------
+**Fixed**
+``BulkFactTable.__init__`` now sets the attributes ``keyrefs``, ``measures``, and ``all``.
+These attributes are required by the ``FactTablePartitioner``.
+
 Version 2.7
 -----------
 **Note**

--- a/pygrametl/tables.py
+++ b/pygrametl/tables.py
@@ -2250,6 +2250,10 @@ class BulkFactTable(_BaseBulkloadable):
              the fact table has foreign keys to some bulk-loaded dimension
              table). Default: ()
         """
+        self.keyrefs = keyrefs
+        self.measures = measures
+        self.all = [k for k in keyrefs] + [m for m in measures]
+        
         # This class does not do much in itself, but looks like a FactTable with
         # keyrefs and measures.
         _BaseBulkloadable.__init__(self,


### PR DESCRIPTION
This should fix issue #48 
The following should be able to run after applying this fix.

```python
import sqlite3

from pygrametl import ConnectionWrapper, parallel
from pygrametl.tables import BulkFactTable, DecoupledFactTable, FactTablePartitioner

connection = sqlite3.connect(":memory:")
cursor = connection.execute("CREATE TABLE test_table(ra INT, rb INT, ma INT, mb INT)")
connection.commit()
cursor.close()


def bulkloader(name: str, attributes, fieldsep, rowsep, nullval, filehandle):
    pass


cw = ConnectionWrapper(connection)
scw = parallel.shareconnectionwrapper(cw, userfuncs=[bulkloader])


fact = DecoupledFactTable(
    BulkFactTable(
        name="test_table",
        keyrefs=["ra", "rb"],
        measures=["ma", "mb"],
        bulkloader=scw.copy().bulkloader,
        usefilename=True
    ),
    returnvalues=False,
)

partitioner = FactTablePartitioner(parts=[fact])

print("START")
for i in range(3000):
    print(i)
    partitioner.insert({"ra": i, "rb": i % 2, "ma": 1, "mb": 2})
scw.commit()
scw.close()
print("END")
```