### PR TITLE
Fix BatchFactTable not converting all None to NULL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Unreleased
 ``BulkFactTable.__init__`` now sets the attributes ``keyrefs``, ``measures``, and ``all``.
 These attributes are required by the ``FactTablePartitioner``.
 
+``BulkFactTable`` constructed with ``usemultirow=True`` (the default is
+``False``) can now load rows containing ``NULL`` values. (GitHub issue #50)
+
 Version 2.7
 -----------
 **Note**

--- a/pygrametl/__init__.py
+++ b/pygrametl/__init__.py
@@ -222,6 +222,19 @@ def getdbfriendlystr(value, nullvalue='None'):
     else:
         return str(value)
 
+def getsqlfriendlystr(value):
+    """Covert a value into a string that can be used in a SQL expression.
+
+       None values are converted to 'NULL'. Strings are surrounded by single
+       quotes and all single quotes in the string are escaped by doubling them.
+       Other values are currently just converted by means of str.
+    """
+    if value is None:
+        return 'NULL'
+    elif type(value) is str:
+        return "'" + value.replace("'", "''") + "'"
+    else:
+        return str(value)
 
 def getstrornullvalue(value, nullvalue='None'):
     """Convert a given value different from None to a string.

--- a/pygrametl/tables.py
+++ b/pygrametl/tables.py
@@ -1868,8 +1868,7 @@ class BatchFactTable(FactTable):
             self.__insertnow = self.__insertmultirow
             self.__basesql = self.insertsql[:self.insertsql.find(' (') + 1]
             self.__rowtovalue = lambda row: '(' + ','.join(map(
-                lambda c: "'" + row[c].replace("'", "''") + "'"
-                if type(row[c]) is str else str(row[c]), self.all)) + ')'
+                lambda c: pygrametl.getsqlfriendlystr(row[c]), self.all)) + ')'
         else:
             self.__insertnow = self.__insertexecutemany
 


### PR DESCRIPTION
As described in GitHub issue #50 the current implementation of `BatchFactTable` cannot insert rows containing `NULL` values if `usemultirow=True` (the default is `False`). This PR adds the function `getsqlfriendlystr()` which converts values to strings that can be used in an SQL expression. It currently converts `None` to `"NULL"`, encapsulates strings in single quotes, escapes all single quotes in strings by doubling them, and converts the remaining values to strings using `str()`. The PR also replaces `BatchFactTable`'s internal value to string conversation logic with a call to  `getsqlfriendlystr()`.