### PR TITLE
More robust ymdparser and ymdhmsparser.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Unreleased
   input is cast to a string. (GitHub issue #40)
 
   ``ymdparser`` can now handle ``datetime.datetime`` and ``datetime.date`` as
-  input. Any other input is cast to a string.
+  input. Any other input is cast to a string.  (GitHub issue #40)
 
 **Fixed**
   ``BulkFactTable.__init__`` now sets the attributes ``keyrefs``, ``measures``,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,11 +5,11 @@ Unreleased
   ``Dimension.ensure`` now explicitly raises a ``TypeError`` with the name of
   the function set as the ``rowexpander``.
 
-  ``ymdhmsparser`` can now handle datetime.datetime as input. Any other input is
-  cast to a str. (GitHub issue #40)
+  ``ymdhmsparser`` can now handle ``datetime.datetime`` as input. Any other
+  input is cast to a str. (GitHub issue #40)
 
-  ``ymdparser`` can now handle datetime.datetime and datetime.date as input.
-  Any other input is cast to a str.
+  ``ymdparser`` can now handle ``datetime.datetime`` and ``datetime.date`` as
+  input. Any other input is cast to a str.
 
 **Fixed**
   ``BulkFactTable.__init__`` now sets the attributes ``keyrefs``, ``measures``,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Unreleased
   input is cast to a string. (GitHub issue #40)
 
   ``ymdparser`` can now handle ``datetime.datetime`` and ``datetime.date`` as
-  input. Any other input is cast to a str.
+  input. Any other input is cast to a string.
 
 **Fixed**
   ``BulkFactTable.__init__`` now sets the attributes ``keyrefs``, ``measures``,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ If a ``rowexpander`` does not return a row in the form of a ``dict``,
 ``Dimension.ensure`` now explicitly raises a ``TypeError`` with the name of the
 function set as the ``rowexpander``.
 
+``ymdhmsparser`` can now handle datetime.datetime as input. Any other input is
+cast to a str. (GitHub issue #40)
+
+``ymdparser`` can now handle datetime.datetime and datetime.date as input. Any
+other input is cast to a str.
+
 **Fixed**
 ``BulkFactTable.__init__`` now sets the attributes ``keyrefs``, ``measures``,
 and ``all``. These attributes are required by the ``FactTablePartitioner``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,22 +1,22 @@
 Unreleased
 ----------
 **Changed**
-If a ``rowexpander`` does not return a row in the form of a ``dict``,
-``Dimension.ensure`` now explicitly raises a ``TypeError`` with the name of the
-function set as the ``rowexpander``.
+  If a ``rowexpander`` does not return a row in the form of a ``dict``,
+  ``Dimension.ensure`` now explicitly raises a ``TypeError`` with the name of
+  the function set as the ``rowexpander``.
 
-``ymdhmsparser`` can now handle datetime.datetime as input. Any other input is
-cast to a str. (GitHub issue #40)
+  ``ymdhmsparser`` can now handle datetime.datetime as input. Any other input is
+  cast to a str. (GitHub issue #40)
 
-``ymdparser`` can now handle datetime.datetime and datetime.date as input. Any
-other input is cast to a str.
+  ``ymdparser`` can now handle datetime.datetime and datetime.date as input.
+  Any other input is cast to a str.
 
 **Fixed**
-``BulkFactTable.__init__`` now sets the attributes ``keyrefs``, ``measures``,
-and ``all``. These attributes are required by the ``FactTablePartitioner``.
+  ``BulkFactTable.__init__`` now sets the attributes ``keyrefs``, ``measures``,
+  and ``all``. These attributes are required by the ``FactTablePartitioner``.
 
-``BulkFactTable`` constructed with ``usemultirow=True`` (the default is
-``False``) can now load rows containing ``NULL`` values. (GitHub issue #50)
+  ``BulkFactTable`` constructed with ``usemultirow=True`` (the default is
+  ``False``) can now load rows containing ``NULL`` values. (GitHub issue #50)
 
 Version 2.7
 -----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Unreleased
   the function set as the ``rowexpander``.
 
   ``ymdhmsparser`` can now handle ``datetime.datetime`` as input. Any other
-  input is cast to a str. (GitHub issue #40)
+  input is cast to a string. (GitHub issue #40)
 
   ``ymdparser`` can now handle ``datetime.datetime`` and ``datetime.date`` as
   input. Any other input is cast to a str.

--- a/pygrametl/__init__.py
+++ b/pygrametl/__init__.py
@@ -444,13 +444,15 @@ def now(ignoredtargetconn=None, ignoredrow=None, ignorednamemapping=None):
 
 
 def ymdparser(ymdstr):
-    """Convert input of the form 'yyyy-MM-dd' to a datetime.date.
+    """Convert an input with a string representation of the form 'yyyy-MM-dd'
+       or a datetime.date or a datetime.datetime to a datetime.date.
 
        If the input is None, the return value is also None.
        If the input is a datetime.date, it is returned.
        If the input is a datetime.datetime, its date is returned.
        Else the input is cast to str and quotes are stripped before it is
        split into the different parts needed to create a datetime.date.
+
     """
     if ymdstr is None:
         return None
@@ -464,7 +466,8 @@ def ymdparser(ymdstr):
 
 
 def ymdhmsparser(ymdhmsstr):
-    """Convert input of the form 'yyyy-MM-dd HH:mm:ss' to a datetime.datetime.
+    """Convert an input with a string representation of the form
+       'yyyy-MM-dd HH:mm:ss' or a datetime.datetime to a datetime.datetime.
 
        If the input is None, the return value is also None.
        If the input is a datetime.datetime, it is returned.

--- a/pygrametl/__init__.py
+++ b/pygrametl/__init__.py
@@ -444,23 +444,38 @@ def now(ignoredtargetconn=None, ignoredrow=None, ignorednamemapping=None):
 
 
 def ymdparser(ymdstr):
-    """Convert a string of the form 'yyyy-MM-dd' to a datetime.date.
+    """Convert input of the form 'yyyy-MM-dd' to a datetime.date.
 
        If the input is None, the return value is also None.
+       If the input is a datetime.date, it is returned.
+       If the input is a datetime.datetime, its date is returned.
+       Else the input is cast to str and quotes are stripped before it is
+       split into the different parts needed to create a datetime.date.
     """
     if ymdstr is None:
         return None
+    elif isinstance(ymdstr, date):
+        return ymdstr
+    elif isinstance(ymdstr, datetime):
+        return ymdstr.date()
+    ymdstr = str(ymdstr).strip("'\"")
     (year, month, day) = ymdstr.split('-')
     return date(int(year), int(month), int(day))
 
 
 def ymdhmsparser(ymdhmsstr):
-    """Convert a string 'yyyy-MM-dd HH:mm:ss' to a datetime.datetime.
+    """Convert input of the form 'yyyy-MM-dd HH:mm:ss' to a datetime.datetime.
 
        If the input is None, the return value is also None.
+       If the input is a datetime.datetime, it is returned.
+       Else the input is cast to str and quotes are stripped before it is
+       split into the different parts needed to create a datetime.datetime.
     """
     if ymdhmsstr is None:
         return None
+    elif isinstance(ymdhmsstr, datetime):
+        return ymdhmsstr
+    ymdhmsstr = str(ymdhmsstr).strip("'\"")
     (datepart, timepart) = ymdhmsstr.strip().split(' ')
     (year, month, day) = datepart.split('-')
     (hour, minute, second) = timepart.split(':')


### PR DESCRIPTION
ymdparser and ymdhmsparser now accept datetime.date(time) as input. Any other input is cast to a str and quotes are removed before it is split into the needed parts to create a datetime.date(time).

Closes GitHub issue #40 and closes GitHub PR #41 (which inspired this).