### PR TITLE
Specify which platforms can run parallel ETL flows

### DIFF
--- a/docs/examples/bulkloading.rst
+++ b/docs/examples/bulkloading.rst
@@ -138,7 +138,7 @@ provided by Transact-SQL can be used.
 There are a number of things to be aware of when using pygrametl with SQL
 Server. If the file used for bulk loading is located on a machine running
 Microsoft Windows, the file must be copied before bulk loading, as the locks
-placed on the file by the OS and pygrametl, prevents SQL Server from opening it
+placed on the file by the OS and pygrametl, prevent SQL Server from opening it
 directly. Copying the file can be done e.g. using `shutil.copyfile
 <https://docs.python.org/3/library/shutil.html#shutil.copyfile>`__.
 

--- a/docs/examples/bulkloading.rst
+++ b/docs/examples/bulkloading.rst
@@ -137,9 +137,9 @@ provided by Transact-SQL can be used.
 
 There are a number of things to be aware of when using pygrametl with SQL
 Server. If the file used for bulk loading is located on a machine running
-Windows, the file must be copied before bulk loading, as the locks placed on the
-file by the OS and pygrametl, prevents SQL Server from opening it directly.
-Copying the file can be done e.g. using `shutil.copyfile
+Microsoft Windows, the file must be copied before bulk loading, as the locks
+placed on the file by the OS and pygrametl, prevents SQL Server from opening it
+directly. Copying the file can be done e.g. using `shutil.copyfile
 <https://docs.python.org/3/library/shutil.html#shutil.copyfile>`__.
 
 By default, BULK INSERT ignores column names, so the number and order of columns

--- a/docs/examples/parallel.rst
+++ b/docs/examples/parallel.rst
@@ -29,7 +29,7 @@ passed row must be modified as the functions return values are ignored.
    pygrametl supports executing parallel ETL flows using CPython (only on
    platforms that start new processes using `fork
    <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`__)
-   or `Jython <http://www.jython.org/>`__. The method used by CPython to start
+   or `Jython <http://www.jython.org/>`__. The method used by CPython to start a
    process can be determined using :func:`.multiprocessing.get_start_method`.
    Unix-like operating systems generally use `fork` by default, but some must be
    configured to use `fork` through :func:`.multiprocessing.set_start_method`.

--- a/docs/examples/parallel.rst
+++ b/docs/examples/parallel.rst
@@ -25,6 +25,18 @@ sequence of functions that run in separate processes. In a flow a row is first
 given to the first function, then the second, and so forth. This also means the
 passed row must be modified as the functions return values are ignored.
 
+.. note::
+   pygrametl supports executing parallel ETL flows using CPython (only on
+   platforms that start new processes using `fork
+   <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`__)
+   or `Jython <http://www.jython.org/>`__. The method used by CPython to start
+   process can be determined using :func:`.multiprocessing.get_start_method`.
+   Unix-like operating systems generally use `fork` by default, but some must be
+   configured to use `fork` through :func:`.multiprocessing.set_start_method`.
+   Microsoft Windows does not support `fork`, thus a Unix-like environment must
+   be installed, e.g., using `Windows Subsystem for Linux
+   <https://learn.microsoft.com/en-us/windows/wsl/>`__.
+
 Due to CPython's `GIL <https://wiki.python.org/moin/GlobalInterpreterLock>`__,
 Jython should be used to run ETL flows that use pygrametl parallel constructs.
 This is because Jython allows threads to be used for parallel processing, while


### PR DESCRIPTION
This PR closes #46 and #47 by [documenting which platforms can execute parallel ETL flows](https://github.com/chrthomsen/pygrametl/blob/document-parallel-limitation/docs/examples/parallel.rst) implemented pygrametl. Currently, pygrametl supports executing parallel ETL flows using CPython on platforms that start new processes using [`fork`](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods) and [Jython](https://github.com/jython/jython). Thus, executing a parallel ETL flow natively on Microsoft Windows using CPython is not supported, and macOS must be configured to use `fork` using [`multiprocessing.set_start_method('fork')`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_start_method) due to the issues with macOS's `fork` implementation documented in [CPython Issue 77906](https://github.com/python/cpython/issues/77906) ([Thanks](https://github.com/chrthomsen/pygrametl/issues/46#issuecomment-1305793956) [to](https://github.com/chrthomsen/pygrametl/issues/46#issuecomment-1305881283) @mFeigeInvia). An  [attempt](https://github.com/chrthomsen/pygrametl/files/10149313/cpython3-spawn-parallel-5d03418b5c8f6d86f0d4eac7917ca1889863839a.txt) to support `spawn` was made, however, it became clear that this would require major changes to pygrametl. This is primarily due to limitations of [`pickle`](https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled) and additional requirements when using [`spawn or forkserver`](https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods) compared to `fork`. As CPython generally does not perform well when executing parallel ETL flows compared to [Jython](https://github.com/chrthomsen/pygrametl/blob/5d03418b5c8f6d86f0d4eac7917ca1889863839a/docs/examples/parallel.rst), @chrthomsen, @fromm1990, and I agreed to prioritize other improvements to pygrametl.