### PR TITLE
Add SQLTransformingSource

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Unreleased
   tests are executed against an in-memory SQLite database so no configuration is
   needed.
 
+  ``SQLTransformingSource`` a new class supporting transforming rows by loading
+  them into a temporary table in an RDBMS and then retrieving them using an SQL
+  query.
+
 **Changed**
   If a ``rowexpander`` does not return a row in the form of a ``dict``,
   ``Dimension.ensure`` now explicitly raises a ``TypeError`` with the name of

--- a/docs/examples/datasources.rst
+++ b/docs/examples/datasources.rst
@@ -298,12 +298,11 @@ default each :class:`.SQLTransformingSource` uses a separate in-memory SQLite
 database but another database can be used by passing a :PEP:`249` connection or
 one of the :class:`.ConnectionWrapper` types as the parameter
 :attr:`.targetconnection`. By using an on-disk database
-:class:`.SQLTransformingSource` can be used with datasets that does not fit in
+:class:`.SQLTransformingSource` can be used with datasets that do not fit in
 memory. If an existing database is used the rows from the data source can also
 be enriched using data from other tables in the database, e.g., by joining the
 rows with an existing table in the database. Be aware that
-:class:`.SQLTransformingSource` creates, truncates, and drops the temporary
-table.
+:class:`.SQLTransformingSource` creates, empties, and drops the temporary table.
 
 .. code-block:: python
 
@@ -312,17 +311,21 @@ table.
 
     sales = TypedCSVSource(f=open('sales.csv', 'r', 16384),
                            casts={'price': int}, delimiter=',')
+
     salesTransformed = SQLTransformingSource(sales,
         "sales", "SELECT product, SUM(price) FROM sales GROUP BY product")
 
-In the above example, the total revenue is computed for each product. In
-addition, to the required parameters shown above,
-:class:`.SQLTransformingSource` also has multiple optional parameters, e.g.,
-:attr:`.extendedcasts` accepts a :class:`.dict` that specifies how Python types
-should be mapped to SQL types, :attr:`.perbatch` specifies if the transformation
-should be applied for each batch of rows or for all rows in the input data
-source, and :attr:`.columnnames` allows the columns in the output rows to be
-renamed.
+In the above example, the total revenue is computed for each product. First, a
+temporary in-memory SQLite database is created. Then a temporary table named
+sales with the same schema as the rows in :attr:`sales` is created. Finally, the
+rows in :attr:`sales` is loaded into the temporary table in batches and then the
+final result is produced by executing the provided SQL query. In addition, to
+the required parameters shown above, :class:`.SQLTransformingSource` also has
+multiple optional parameters, e.g., :attr:`.extendedcasts` accepts a
+:class:`.dict` that specifies how Python types should be mapped to SQL types,
+:attr:`.perbatch` specifies if the transformation should be applied for each
+batch of rows or for all rows in the input data source, and :attr:`.columnnames`
+allows the columns in the output rows to be renamed.
 
 CrossTabbingSource
 ------------------

--- a/docs/examples/datasources.rst
+++ b/docs/examples/datasources.rst
@@ -289,6 +289,41 @@ the form :attr:`f(row)`, which will be applied to the source in the given order.
 In the above example, the price is converted from a string to an integer and
 stored in the row as two currencies.
 
+SQLTransformingSource
+---------------------
+:class:`.SQLTransformingSource` can be used to transform the rows of a data
+source using SQL. :class:`.SQLTransformingSource` loads the rows into a
+temporary table in an RDBMS and then retrieves them using an SQL query. By
+default each :class:`.SQLTransformingSource` uses a separate in-memory SQLite
+database but another database can be used by passing a :PEP:`249` connection or
+one of the :class:`.ConnectionWrapper` types as the parameter
+:attr:`.targetconnection`. By using an on-disk database
+:class:`.SQLTransformingSource` can be used with datasets that does not fit in
+memory. If an existing database is used the rows from the data source can also
+be enriched using data from other tables in the database, e.g., by joining the
+rows with an existing table in the database. Be aware that
+:class:`.SQLTransformingSource` creates, truncates, and drops the temporary
+table.
+
+.. code-block:: python
+
+    import pygrametl
+    from pygrametl.datasources import TypedCSVSource, SQLTransformingSource
+
+    sales = TypedCSVSource(f=open('sales.csv', 'r', 16384),
+                           casts={'price': int}, delimiter=',')
+    salesTransformed = SQLTransformingSource(sales,
+        "sales", "SELECT product, SUM(price) FROM sales GROUP BY product")
+
+In the above example, the total revenue is computed for each product. In
+addition, to the required parameters shown above,
+:class:`.SQLTransformingSource` also has multiple optional parameters, e.g.,
+:attr:`.extendedcasts` accepts a :class:`.dict` that specifies how Python types
+should be mapped to SQL types, :attr:`.perbatch` specifies if the transformation
+should be applied for each batch of rows or for all rows in the input data
+source, and :attr:`.columnnames` allows the columns in the output rows to be
+renamed.
+
 CrossTabbingSource
 ------------------
 :class:`.CrossTabbingSource` can be used to compute the cross tab of a data

--- a/pygrametl/datasources.py
+++ b/pygrametl/datasources.py
@@ -29,6 +29,11 @@
 
 from csv import DictReader
 import sys
+import sqlite3
+
+import pygrametl
+from pygrametl import tables
+from pygrametl import ConnectionWrapper
 
 
 if sys.platform.startswith('java'):
@@ -46,8 +51,9 @@ except ImportError:
 __all__ = ['CSVSource', 'TypedCSVSource', 'SQLSource', 'PandasSource',
            'JoiningSource', 'HashJoiningSource', 'MergeJoiningSource',
            'BackgroundSource', 'ProcessSource', 'MappingSource',
-           'TransformingSource', 'UnionSource', 'CrossTabbingSource',
-           'FilteringSource', 'DynamicForEachSource', 'RoundRobinSource']
+           'TransformingSource', 'SQLTransformingSource', 'UnionSource',
+           'CrossTabbingSource', 'FilteringSource', 'DynamicForEachSource',
+           'RoundRobinSource']
 
 
 CSVSource = DictReader
@@ -393,6 +399,134 @@ class TransformingSource(object):
             for func in self.__transformations:
                 func(row)
             yield row
+
+
+class SQLTransformingSource(object):
+
+    """A source that transforms rows from another source by loading them into a
+       temporary table in an RDBMS and then retrieve them using an SQL query.
+
+       .. Warning::
+          Creates, truncates, and drops the temporary table.
+    """
+
+    def __init__(self, source, tablename, query, extendedcasts=None,
+                 batchsize=10000, perbatch=False, columnnames=None,
+                 targetconnection=None):
+        """Arguments:
+
+        - source: a data source that yields rows with an equivalent schema
+        - tablename: a string with the name of the temporary table to use
+        - query: the query that transforms the rows from source
+        - extendedcasts: a dictionary that maps from Python types to SQL types
+          in the form of strings. Default: {}
+        - batchsize: an int deciding how many insert operations should be done
+          in one batch. Default: 10000
+        - perbatch: a boolean deciding if the transformation should be applied
+          for each batch or for all rows in source. Default: False
+        - columnnames: a sequence of column names to use for transformed rows
+        - targetconnection: the PEP 249 connection to use, the ConnectionWrapper
+          to use, or None. If None, a new temporary in-memory SQLite database is
+          created.
+        """
+        self.__source = source
+        self.__query = query
+        self.__batchsize = batchsize
+        self.__perbatch = perbatch
+        self.__columnnames = columnnames
+
+        # Extensible mapping of Python types to SQL types
+        self.__casts = {
+            int: "INTEGER",
+            float: "DOUBLE PRECISION",
+            str: "VARCHAR(4000)",  # Maximum size for Oracle 11g R2
+        }
+
+        if extendedcasts:
+            self.__casts |= extendedcasts
+
+        # Only close the connection if it is created by SQLTransformingSource
+        if targetconnection is None:
+            self.__close = True
+            targetconnection = sqlite3.connect(":memory:")
+        else:
+            self.__close = False
+
+        # Check if targetconnection is a ConnectioNWrapper without importing
+        # modules that require Jython when running under CPython and vice versa.
+        # A ConnectionWrapper is always used to support multiple paramstyles
+        if hasattr(targetconnection, "getunderlyingmodule") and \
+           callable(targetconnection.getunderlyingmodule):
+            self.__targetconnection = targetconnection
+        else:
+            self.__targetconnection = ConnectionWrapper(targetconnection)
+
+            # Ensure the implicitly created ConnectionWrapper is not default
+            if self.__targetconnection == \
+               pygrametl.getdefaulttargetconnection():
+                pygrametl._defaulttargetconnection = None
+
+        # Create table SQL
+        self.__batch = []
+        row = next(source)
+        self.__batch.append(row)
+
+        createsql = "CREATE TABLE {}({})".format(tablename, ', '.join(
+            [name + " " + self.__casts[type(value)]
+             for name, value in row.items()]))
+        self.__targetconnection.execute(createsql)
+        self.__targetconnection.commit()
+
+        # Create insert SQL
+        # This gives "INSERT INTO tablename(att1, att2, att3, ...)
+        #             VALUES (%(att1)s, %(att2)s, %(att3)s, ...)"
+        quote = tables._quote
+        quotelist = lambda x: [quote(xn) for xn in x]
+        self.__insertsql = "INSERT INTO " + tablename \
+            + "(" + ", ".join(quotelist(row.keys())) + ") VALUES (" + \
+            ", ".join(["%%(%s)s" % (att,) for att in row.keys()]) + ")"
+
+        # Create drop and truncate SQL
+        self.__dropsql = "DROP TABLE " + tablename
+        self.__deletefrom = "DELETE FROM " + tablename  # No TRUNCATE in SQLite
+
+    def __iter__(self):
+        for row in self.__source:
+            # Insert and maybe transform current batch
+            if len(self.__batch) == self.__batchsize:
+                self.__insertnow()
+                if self.__perbatch:
+                    for transformed_row in self.__transform():
+                        yield transformed_row
+                    self.__targetconnection.execute(self.__deletefrom)
+
+            # The first row is read and added in __init__
+            self.__batch.append(row)
+
+        # Insert last batch and transform last or entire batch
+        self.__insertnow()
+        for transformed_row in self.__transform():
+            yield transformed_row
+
+        # Cleanup
+        self.__targetconnection.execute(self.__dropsql)
+        self.__targetconnection.commit()
+        if self.__close:
+            self.__targetconnection.close()
+
+    def __insertnow(self):
+        if self.__batch:
+            self.__targetconnection.executemany(self.__insertsql, self.__batch)
+            self.__targetconnection.commit()
+            self.__batch.clear()
+
+    def __transform(self):
+        self.__targetconnection.execute(self.__query)
+
+        if self.__columnnames:
+            return self.__targetconnection.rowfactory(self.__columnnames)
+        else:
+            return self.__targetconnection.rowfactory()
 
 
 class CrossTabbingSource(object):

--- a/pygrametl/datasources.py
+++ b/pygrametl/datasources.py
@@ -404,30 +404,42 @@ class TransformingSource(object):
 class SQLTransformingSource(object):
 
     """A source that transforms rows from another source by loading them into a
-       temporary table in an RDBMS and then retrieve them using an SQL query.
+       temporary table in an RDBMS and then retrieving them using an SQL query.
 
        .. Warning::
-          Creates, truncates, and drops the temporary table.
+          Creates, empties, and drops the temporary table.
     """
 
-    def __init__(self, source, tablename, query, extendedcasts=None,
+    def __init__(self, source, temptablename, query, additionalcasts=None,
                  batchsize=10000, perbatch=False, columnnames=None,
-                 targetconnection=None):
+                 usetruncate=False, targetconnection=None):
         """Arguments:
 
-        - source: a data source that yields rows with an equivalent schema
-        - tablename: a string with the name of the temporary table to use
-        - query: the query that transforms the rows from source
-        - extendedcasts: a dictionary that maps from Python types to SQL types
-          in the form of strings. Default: {}
+        - source: a data source that yields rows with the same schema, i.e.,
+          they contain the same columns and the columns' types does not change
+        - tablename: a string with the name of the temporary table to use. This
+          table must use the same schema as the rows from source
+        - query: the query that is executed on temptablename in targetconnection
+          or an in-memory SQLite database to transforms the rows from source
+        - additionalcasts: a dict with additional casts from Python types to SQL
+          types in the form of strings that takes precedences over the default.
+          Default: None, i.e., only int, float, and str is mapped to simple SQL
+          types that should be supported by most RDBMSs
         - batchsize: an int deciding how many insert operations should be done
           in one batch. Default: 10000
         - perbatch: a boolean deciding if the transformation should be applied
-          for each batch or for all rows in source. Default: False
-        - columnnames: a sequence of column names to use for transformed rows
+          for each batch or for all rows in source.
+          Default: False, i.e., the transformation is applied once for all rows
+          in source
+        - columnnames: a sequence of column names to use for transformed rows.
+          Default: None, i.e., the column names from query is used
+        - usetruncate: a boolean deciding if TRUNCATE should be used instead of
+          DELETE FROM when emptying temptablename in targetconnection or an
+          in-memory SQLite database
+          Default: False, i.e., DELETE FROM is used instead of TRUNCATE
         - targetconnection: the PEP 249 connection to use, the ConnectionWrapper
           to use, or None. If None, a new temporary in-memory SQLite database is
-          created.
+          created
         """
         self.__source = source
         self.__query = query
@@ -442,8 +454,8 @@ class SQLTransformingSource(object):
             str: "VARCHAR(4000)",  # Maximum size for Oracle 11g R2
         }
 
-        if extendedcasts:
-            self.__casts |= extendedcasts
+        if additionalcasts:
+            self.__casts |= additionalcasts
 
         # Only close the connection if it is created by SQLTransformingSource
         if targetconnection is None:
@@ -455,8 +467,7 @@ class SQLTransformingSource(object):
         # Check if targetconnection is a ConnectioNWrapper without importing
         # modules that require Jython when running under CPython and vice versa.
         # A ConnectionWrapper is always used to support multiple paramstyles
-        if hasattr(targetconnection, "getunderlyingmodule") and \
-           callable(targetconnection.getunderlyingmodule):
+        if "ConnectionWrapper" in type(targetconnection).__name__:
             self.__targetconnection = targetconnection
         else:
             self.__targetconnection = ConnectionWrapper(targetconnection)
@@ -471,7 +482,7 @@ class SQLTransformingSource(object):
         row = next(source)
         self.__batch.append(row)
 
-        createsql = "CREATE TABLE {}({})".format(tablename, ', '.join(
+        createsql = "CREATE TABLE {}({})".format(temptablename, ', '.join(
             [name + " " + self.__casts[type(value)]
              for name, value in row.items()]))
         self.__targetconnection.execute(createsql)
@@ -482,13 +493,17 @@ class SQLTransformingSource(object):
         #             VALUES (%(att1)s, %(att2)s, %(att3)s, ...)"
         quote = tables._quote
         quotelist = lambda x: [quote(xn) for xn in x]
-        self.__insertsql = "INSERT INTO " + tablename \
+        self.__insertsql = "INSERT INTO " + temptablename \
             + "(" + ", ".join(quotelist(row.keys())) + ") VALUES (" + \
             ", ".join(["%%(%s)s" % (att,) for att in row.keys()]) + ")"
 
         # Create drop and truncate SQL
-        self.__dropsql = "DROP TABLE " + tablename
-        self.__deletefrom = "DELETE FROM " + tablename  # No TRUNCATE in SQLite
+        self.__dropsql = "DROP TABLE " + temptablename
+        if usetruncate:
+            self.__deletefrom = "TRUNCATE TABLE " + temptablename
+        else:
+            # TRUNCATE is not supported in SQLite
+            self.__deletefrom = "DELETE FROM " + temptablename
 
     def __iter__(self):
         for row in self.__source:

--- a/pygrametl/datasources.py
+++ b/pygrametl/datasources.py
@@ -432,7 +432,7 @@ class SQLTransformingSource(object):
           Default: False, i.e., the transformation is applied once for all rows
           in source
         - columnnames: a sequence of column names to use for transformed rows.
-          Default: None, i.e., the column names from query is used
+          Default: None, i.e., the column names from query are used
         - usetruncate: a boolean deciding if TRUNCATE should be used instead of
           DELETE FROM when emptying temptablename in targetconnection.
           Default: True, i.e.,  TRUNCATE is used instead of DELETE FROM

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -86,18 +86,6 @@ class SQLTransformationSourceTest(unittest.TestCase):
         self.assertIsNone(pygrametl.getdefaulttargetconnection())
         self.assertEqual(expected_group_by_genre_per_batch, list(source))
 
-    def test_transform_with_batch_size_of_one_perbatch_and_truncate(self):
-        source = SQLTransformingSource(
-            iter(self.input_list), "book",
-            "SELECT genre, COUNT(title) FROM book GROUP BY genre",
-            batchsize=1, perbatch=True, usetruncate=True)
-
-        self.assertIsNone(pygrametl.getdefaulttargetconnection())
-        with self.assertRaises(sqlite3.OperationalError) as cm:
-            list(source)
-
-        self.assertEqual(str(cm.exception), "near \"TRUNCATE\": syntax error")
-
     def test_transform_with_renamed_columns(self):
         expected_group_by_genre_renamed = [
             {"genre": "Comic", "count": 2},

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -96,10 +96,7 @@ class SQLTransformationSourceTest(unittest.TestCase):
         with self.assertRaises(sqlite3.OperationalError) as cm:
             list(source)
 
-        e = cm.exception
-        self.assertEqual(e.sqlite_errorname, "SQLITE_ERROR")
-        self.assertEqual(e.sqlite_errorcode, 1)
-        self.assertEqual(str(e), "near \"TRUNCATE\": syntax error")
+        self.assertEqual(str(cm.exception), "near \"TRUNCATE\": syntax error")
 
     def test_transform_with_renamed_columns(self):
         expected_group_by_genre_renamed = [

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -43,10 +43,10 @@ class SQLTransformationSourceTest(unittest.TestCase):
         ]
 
         cls.expected_group_by_genre = [
-            {'genre': 'Comic', 'COUNT(title)': 2},
-            {'genre': 'Cookbook', 'COUNT(title)': 1},
-            {'genre': 'Novel', 'COUNT(title)': 1},
-            {'genre': 'Unknown', 'COUNT(title)': 1}
+            {"genre": "Comic", "COUNT(title)": 2},
+            {"genre": "Cookbook", "COUNT(title)": 1},
+            {"genre": "Novel", "COUNT(title)": 1},
+            {"genre": "Unknown", "COUNT(title)": 1}
         ]
 
         # Ensure other tests does not affect these tests
@@ -71,11 +71,11 @@ class SQLTransformationSourceTest(unittest.TestCase):
 
     def test_transform_with_batch_size_of_one_and_perbatch(self):
         expected_group_by_genre_per_batch = [
-            {'genre': 'Unknown', 'COUNT(title)': 1},
-            {'genre': 'Novel', 'COUNT(title)': 1},
-            {'genre': 'Comic', 'COUNT(title)': 1},
-            {'genre': 'Comic', 'COUNT(title)': 1},
-            {'genre': 'Cookbook', 'COUNT(title)': 1}
+            {"genre": "Unknown", "COUNT(title)": 1},
+            {"genre": "Novel", "COUNT(title)": 1},
+            {"genre": "Comic", "COUNT(title)": 1},
+            {"genre": "Comic", "COUNT(title)": 1},
+            {"genre": "Cookbook", "COUNT(title)": 1}
         ]
 
         source = SQLTransformingSource(
@@ -100,10 +100,10 @@ class SQLTransformationSourceTest(unittest.TestCase):
 
     def test_transform_with_renamed_columns(self):
         expected_group_by_genre_renamed = [
-            {'genre': 'Comic', 'count': 2},
-            {'genre': 'Cookbook', 'count': 1},
-            {'genre': 'Novel', 'count': 1},
-            {'genre': 'Unknown', 'count': 1}
+            {"genre": "Comic", "count": 2},
+            {"genre": "Cookbook", "count": 1},
+            {"genre": "Novel", "count": 1},
+            {"genre": "Unknown", "count": 1}
         ]
 
         source = SQLTransformingSource(

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2023, Aalborg University (pygrametl@cs.aau.dk)
+# All rights reserved.
+
+# Redistribution and use in source anqd binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sqlite3
+import unittest
+
+import pygrametl
+from pygrametl.datasources import SQLTransformingSource
+from tests import utilities
+
+
+class SQLTransformationSourceTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.input_list = [
+            { "id": 1, "title": "Unknown", "genre": "Unknown" },
+            { "id": 2, "title": "Nineteen Eighty-Four", "genre": "Novel" },
+            { "id": 3, "title": "Calvin and Hobbes One", "genre": "Comic" },
+            { "id": 4, "title": "Calvin and Hobbes Two", "genre": "Comic" },
+            { "id": 5, "title": "The Silver Spoon", "genre": "Cookbook" }
+        ]
+
+        cls.expected_group_by_genre = [
+            {'genre': 'Comic', 'COUNT(title)': 2},
+            {'genre': 'Cookbook', 'COUNT(title)': 1},
+            {'genre': 'Novel', 'COUNT(title)': 1},
+            {'genre': 'Unknown', 'COUNT(title)': 1}
+        ]
+
+        # Ensure other tests does not affect these tests
+        utilities.remove_default_connection_wrapper()
+
+    def test_transform(self):
+        source = SQLTransformingSource(
+            iter(self.input_list), "book",
+            "SELECT genre, COUNT(title) FROM book GROUP BY genre")
+
+        self.assertIsNone(pygrametl.getdefaulttargetconnection())
+        self.assertEqual(self.expected_group_by_genre, list(source))
+
+    def test_transform_with_batch_size_of_one(self):
+        source = SQLTransformingSource(
+            iter(self.input_list), "book",
+            "SELECT genre, COUNT(title) FROM book GROUP BY genre",
+            batchsize=1)
+
+        self.assertIsNone(pygrametl.getdefaulttargetconnection())
+        self.assertEqual(self.expected_group_by_genre, list(source))
+
+    def test_transform_with_batch_size_of_one_and_perbatch(self):
+        expected_group_by_genre_per_batch = [
+            {'genre': 'Unknown', 'COUNT(title)': 1},
+            {'genre': 'Novel', 'COUNT(title)': 1},
+            {'genre': 'Comic', 'COUNT(title)': 1},
+            {'genre': 'Comic', 'COUNT(title)': 1},
+            {'genre': 'Cookbook', 'COUNT(title)': 1}
+        ]
+
+        source = SQLTransformingSource(
+            iter(self.input_list), "book",
+            "SELECT genre, COUNT(title) FROM book GROUP BY genre",
+            batchsize=1, perbatch=True)
+
+        self.assertIsNone(pygrametl.getdefaulttargetconnection())
+        self.assertEqual(expected_group_by_genre_per_batch, list(source))
+
+    def test_transform_with_renamed_columns(self):
+        expected_group_by_genre_renamed = [
+            {'genre': 'Comic', 'count': 2},
+            {'genre': 'Cookbook', 'count': 1},
+            {'genre': 'Novel', 'count': 1},
+            {'genre': 'Unknown', 'count': 1}
+        ]
+
+        source = SQLTransformingSource(
+            iter(self.input_list), "book",
+            "SELECT genre, COUNT(title) FROM book GROUP BY genre",
+            columnnames=["genre", "count"])
+
+        self.assertIsNone(pygrametl.getdefaulttargetconnection())
+        self.assertEqual(expected_group_by_genre_renamed, list(source))
+
+    def test_transform_with_pep_connection(self):
+        source = SQLTransformingSource(
+            iter(self.input_list), "book",
+            "SELECT genre, COUNT(title) FROM book GROUP BY genre",
+            targetconnection=sqlite3.connect(":memory:"))
+
+        self.assertIsNone(pygrametl.getdefaulttargetconnection())
+        self.assertEqual(self.expected_group_by_genre, list(source))
+
+    def test_transform_with_connection_wrapper(self):
+        source = SQLTransformingSource(
+            iter(self.input_list), "book",
+            "SELECT genre, COUNT(title) FROM book GROUP BY genre",
+            targetconnection=utilities.ensure_default_connection_wrapper())
+
+        # Ensure this test does not affect the other tests even if it fails
+        utilities.remove_default_connection_wrapper()
+        self.assertEqual(self.expected_group_by_genre, list(source))

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -57,6 +57,7 @@ def get_connection():
 def ensure_default_connection_wrapper():
     """Ensure the default connection wrapper is ready for the next test."""
     connection_wrapper = pygrametl.getdefaulttargetconnection()
+
     try:
         connection_wrapper.rollback()
     except Exception:
@@ -68,6 +69,11 @@ def ensure_default_connection_wrapper():
     # The database must be in a known good state before each test
     pygrametl.drawntabletesting.Table.clear()
     return connection_wrapper
+
+
+def remove_default_connection_wrapper():
+    """Ensure there is no default connection wrapper set."""
+    pygrametl._defaulttargetconnection = None
 
 
 def __sqlite3_connection(connection_string):


### PR DESCRIPTION
This PR adds a new class to `datasources.py` named `SQLTransformingSource` which provides support for transforming rows using SQL by loading them into a temporary table in an RDBMS and then retrieving them using an SQL query. There are two open questions related to the current implementation: 
1. Can/should a most robust method for checking if `targetconnection` is one the `ConnectionWrapper` types be used? Currently the code simply assumes `targetconnection` is one of the `ConnectionWrapper` types if it implements a method named `getunderlyingmodule`.
2. Can/should `quote`, `quotelist`, and `insertsql` be shared be between `Dimension` and `SQLTransformingSource` and if so how? 