### PR TITLE
Dev/scd lookupasof

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Unreleased
   tests are executed against an in-memory SQLite database so no configuration is
   needed.
 
+  ``SlowlyChangingDimension.lookupasof`` allows to lookup the version that was
+  valid at a given time.
+
 **Changed**
   If a ``rowexpander`` does not return a row in the form of a ``dict``,
   ``Dimension.ensure`` now explicitly raises a ``TypeError`` with the name of
@@ -15,6 +18,12 @@ Unreleased
 
   ``ymdparser`` can now handle ``datetime.datetime`` and ``datetime.date`` as
   input. Any other input is cast to a string.  (GitHub issue #40)
+
+  If ``orderingatt`` is not specified for a ``SlowlyChangingDimension``,
+  ``fromatt`` will now be used if ``versionatt`` are ``toatt`` not specified.
+
+  When using ``fromatt`` or ``toatt`` as ``orderingatt``, the generated SQL
+  will specify NULLS FIRST or NULLS LAST.
 
 **Fixed**
   ``BulkFactTable.__init__`` now sets the attributes ``keyrefs``, ``measures``,

--- a/tests/tables/test_Dimension.py
+++ b/tests/tables/test_Dimension.py
@@ -1286,12 +1286,11 @@ class SlowlyChangingDimensionTest(DimensionTest):
 
         self.assertEqual(3, self.test_dimension.lookup({"name": "Ann"}))
 
-    def test_orderingatt_versionatt_toatt_are_all_none(self):
+    def test_orderingatt_versionatt_fromatt_toatt_are_all_none(self):
         self.assertRaises(ValueError, SlowlyChangingDimension, name=self.initial.name,
                           key=self.initial.key(),
                           attributes=self.initial.attributes,
                           lookupatts=['name'],
-                          fromatt='fromdate',
                           cachesize=100,
                           prefill=True)
 


### PR DESCRIPTION
Initial attempt to make a `lookupasof` on `SlowlyChangingDimension`. 

- lookupasof and helper functions added to `SlowlyChangingDimension`
- the SQL for looking up keys, explicitly uses "NULLS FIRST" or "NULLS LAST"
- `fromatt` is now allowed to be used as `orderingatt`
- A unittest updated to reflect that `fromatt` can be `orderingatt`

