### PR TITLE
SlowlyChangingDimension type1 update only latest

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 Unreleased
 ----------
+**Added**
+  Support for specifying if all or only the latest version of a member should be
+  updated when type 1 updates are applied to``SlowlyChangingDimension`.
+
 **Fixed**
   All uses of ``open()`` in the beginner guide now include "utf-8" to minimize
   the chance of errors due to different encodings.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ Unreleased
 ----------
 **Added**
   Support for specifying if all or only the latest version of a member should be
-  updated when type 1 updates are applied to``SlowlyChangingDimension`.
+  updated when type 1 updates are applied to ``SlowlyChangingDimension``.
 
 **Fixed**
   All uses of ``open()`` in the beginner guide now include "utf-8" to minimize

--- a/pygrametl/tables.py
+++ b/pygrametl/tables.py
@@ -1322,7 +1322,8 @@ class SlowlyChangingDimension(Dimension):
 
     def __preparetype1updates(self, updates, lookupvalues, type2changes):
         """ """
-        # Perform type 1 updates for the latest version
+        # Perform type 1 updates for the latest version unless type2changes is
+        # True as the latest version then is a new version about to be inserted
         updateslatest = { att:value for (att, value) in updates.items()
                           if not self.type1attsupdateall[att] }
         if updateslatest and not type2changes:

--- a/pygrametl/tables.py
+++ b/pygrametl/tables.py
@@ -1220,7 +1220,7 @@ class SlowlyChangingDimension(Dimension):
 
             if len(type1updates) > 0:
                 # Some type 1 updates were found
-                self.__preparetype1updates(type1updates, other)
+                self.__preparetype1updates(type1updates, other, addnewversion)
 
             if addnewversion:  # type 2
                 # Make a new row version and insert it
@@ -1320,20 +1320,19 @@ class SlowlyChangingDimension(Dimension):
             tmp[self.key] = newkeyvalue
             self._after_getbykey(newkeyvalue, tmp)
 
-    def __preparetype1updates(self, updates, lookupvalues, namemapping={}):
+    def __preparetype1updates(self, updates, lookupvalues, type2changes):
         """ """
         # Perform type 1 updates for the latest version
         updateslatest = { att:value for (att, value) in updates.items()
                           if not self.type1attsupdateall[att] }
-        if updateslatest:
+        if updateslatest and not type2changes:
             self.__performtype1updates([lookupvalues[self.key]], updateslatest)
 
         # Perform type 1 updates for all version
         updatesall = { att:value for (att, value) in updates.items()
                        if self.type1attsupdateall[att] }
         if updatesall:
-            self.targetconnection.execute(self.keylookupsql, lookupvalues,
-                                          namemapping)
+            self.targetconnection.execute(self.keylookupsql, lookupvalues)
             updatekeys = [e[0] for e in self.targetconnection.fetchalltuples()]
             updatekeys.reverse()
             self.__performtype1updates(updatekeys, updatesall)

--- a/pygrametl/tables.py
+++ b/pygrametl/tables.py
@@ -1220,7 +1220,7 @@ class SlowlyChangingDimension(Dimension):
 
             if len(type1updates) > 0:
                 # Some type 1 updates were found
-                self.__performtype1updates(type1updates, other)
+                self.__preparetype1updates(type1updates, other)
 
             if addnewversion:  # type 2
                 # Make a new row version and insert it
@@ -1320,13 +1320,13 @@ class SlowlyChangingDimension(Dimension):
             tmp[self.key] = newkeyvalue
             self._after_getbykey(newkeyvalue, tmp)
 
-    def __performtype1updates(self, updates, lookupvalues, namemapping={}):
+    def __preparetype1updates(self, updates, lookupvalues, namemapping={}):
         """ """
         # Perform type 1 updates for the latest version
         updateslatest = { att:value for (att, value) in updates.items()
                           if not self.type1attsupdateall[att] }
         if updateslatest:
-            self.__executetype1updates([lookupvalues[self.key]], updateslatest)
+            self.__performtype1updates([lookupvalues[self.key]], updateslatest)
 
         # Perform type 1 updates for all version
         updatesall = { att:value for (att, value) in updates.items()
@@ -1336,9 +1336,9 @@ class SlowlyChangingDimension(Dimension):
                                           namemapping)
             updatekeys = [e[0] for e in self.targetconnection.fetchalltuples()]
             updatekeys.reverse()
-            self.__executetype1updates(updatekeys, updatesall)
+            self.__performtype1updates(updatekeys, updatesall)
 
-    def __executetype1updates(self, updatekeys, updates):
+    def __performtype1updates(self, updatekeys, updates):
         """ """
         # Generate SQL for the update
         valparts = ", ".join(

--- a/pygrametl/tables.py
+++ b/pygrametl/tables.py
@@ -933,8 +933,8 @@ class SlowlyChangingDimension(Dimension):
         self.maxto = maxto
         self.srcdateatt = srcdateatt
         self.srcdateparser = srcdateparser
-        self.type1atts = set(
-            [att if type(att) is str else att[0] for att in type1atts])
+        self.type1atts = \
+            [att if type(att) is str else att[0] for att in type1atts]
         self.type1attsupdateall = dict(
             [(att, True) if type(att) is str else att for att in type1atts])
         self.useorderby = useorderby
@@ -950,7 +950,7 @@ class SlowlyChangingDimension(Dimension):
 
         # Check that versionatt, fromatt and toatt are also declared as
         # attributes
-        for var in (orderingatt, versionatt, fromatt, toatt):
+        for var in [orderingatt, versionatt, fromatt, toatt] + self.type1atts:
             if var and var not in attributes:
                 raise ValueError("%s not present in attributes argument" %
                                  (var,))

--- a/pygrametl/tables.py
+++ b/pygrametl/tables.py
@@ -935,6 +935,10 @@ class SlowlyChangingDimension(Dimension):
         self.srcdateparser = srcdateparser
         self.type1atts = \
             [att if type(att) is str else att[0] for att in type1atts]
+        type1lookupatts = set(self.type1atts) & set(self.lookupatts)
+        if type1lookupatts:
+            raise ValueError(", ".join(type1lookupatts) +
+                             " in both type1atts and lookupatts argument")
         self.type1attsupdateall = dict(
             [(att, True) if type(att) is str else att for att in type1atts])
         self.useorderby = useorderby
@@ -997,7 +1001,7 @@ class SlowlyChangingDimension(Dimension):
             # There could be NULLs in toatt and fromatt. See the explanation for
             # the orderingatt argument above
             if self.orderingatt == self.toatt:
-                self.keyvaliditylookupsql += " NULLS LAST" 
+                self.keyvaliditylookupsql += " NULLS LAST"
             elif self.orderingatt == self.fromatt:
                 self.keyvaliditylookupsql += " NULLS FIRST"
 

--- a/tests/tables/test_Dimension.py
+++ b/tests/tables/test_Dimension.py
@@ -901,7 +901,7 @@ class SlowlyChangingDimensionTest(DimensionTest):
             versionatt='version',
             fromatt='fromdate',
             toatt='todate',
-            type1atts='age',
+            type1atts=['age'],
             srcdateatt='from',
             cachesize=100,
             prefill=True)
@@ -1142,7 +1142,7 @@ class SlowlyChangingDimensionTest(DimensionTest):
             {'name': 'Ann', 'age': 21, 'city': 'Aarhus', 'from': '2010-03-03'})
         postcondition.assertEqual()
 
-    def test_scdensure_type1_change_new_row(self):
+    def test_scdensure_type1_change_all_rows(self):
         # A new row should be inserted for Ann and age should be 21 in all rows
         postcondition = self.initial.update(0, "| 1 | Ann | 21 | Aalborg | 2010-01-01 | 2010-03-03 | 1 |") \
                                     .update(2, "| 3 | Ann | 21 | Aarhus  | 2010-03-03 | 2010-04-04 | 2 |") \
@@ -1150,6 +1150,16 @@ class SlowlyChangingDimensionTest(DimensionTest):
 
         self.test_dimension.scdensure(
             {'name': 'Ann', 'age': 21, 'city': 'Aabenraa', 'from': '2010-04-04'})
+
+        postcondition.assertEqual()
+
+    def test_scdensure_type1_change_only_latest_rows(self):
+        # No new rows should be inserted for Ann and age should be 21 in the latest row
+        postcondition = self.initial.update(2, "| 3 | Ann | 21 | Aarhus | 2010-03-03 | NULL | 2 |")
+        self.test_dimension.type1attsupdateall['age'] = False  # Only update the latest version
+
+        self.test_dimension.scdensure(
+            {'name': 'Ann', 'age': 21, 'city': 'Aarhus', 'from': '2010-03-03'})
 
         postcondition.assertEqual()
 

--- a/tests/tables/test_Dimension.py
+++ b/tests/tables/test_Dimension.py
@@ -1193,6 +1193,17 @@ class SlowlyChangingDimensionTest(DimensionTest):
 
         postcondition.assertEqual()
 
+    def test_scdensure_type1_and_type2_change_only_latest_rows(self):
+        # No new rows should be inserted for Ann and age should be 21 in the latest row
+        postcondition = self.initial.update(2, "| 3 | Ann | 20 | Aarhus  | 2010-03-03 | 2010-04-05 | 2 |") \
+                                    + "| 5 | Ann | 21 | Aalborg | 2010-04-05 | NULL | 3 |"
+        self.test_dimension.type1attsupdateall['age'] = False  # Only update the latest version
+
+        self.test_dimension.scdensure(
+            {'name': 'Ann', 'age': 21, 'city': 'Aalborg', 'from': '2010-04-05'})
+
+        postcondition.assertEqual()
+
     def test_scdensure_two_newversions(self):
         postcondition = self.initial.update(
             2, "| 3 | Ann | 20 | Aarhus | 2010-03-03 | 2010-04-04 | 2 |") \

--- a/tests/tables/test_Dimension.py
+++ b/tests/tables/test_Dimension.py
@@ -1006,6 +1006,21 @@ class SlowlyChangingDimensionTest(DimensionTest):
                 cachesize=100,
                 prefill=True)
 
+    def test_type1atts_cannot_be_lookupatts(self):
+        with self.assertRaises(ValueError):
+            SlowlyChangingDimension(
+                name=self.initial.name,
+                key=self.initial.key(),
+                attributes=self.initial.attributes,
+                lookupatts=['name', "age"],
+                versionatt='version',
+                fromatt='fromdate',
+                toatt='todate',
+                type1atts=['age'],
+                srcdateatt='from',
+                cachesize=100,
+                prefill=True)
+
     # The lookup method in Dimension is overridden in SlowlyChangingDimension
     def test_lookup(self):
         postcondition = self.initial

--- a/tests/tables/test_Dimension.py
+++ b/tests/tables/test_Dimension.py
@@ -991,6 +991,21 @@ class SlowlyChangingDimensionTest(DimensionTest):
                  "fromdate": "2010-02-02", "todate": "2010-02-02",
                  "version": 1}]
 
+    def test_type1atts_must_be_attributes(self):
+        with self.assertRaises(ValueError):
+            SlowlyChangingDimension(
+                name=self.initial.name,
+                key=self.initial.key(),
+                attributes=self.initial.attributes,
+                lookupatts=['name'],
+                versionatt='version',
+                fromatt='fromdate',
+                toatt='todate',
+                type1atts=['surname'],
+                srcdateatt='from',
+                cachesize=100,
+                prefill=True)
+
     # The lookup method in Dimension is overridden in SlowlyChangingDimension
     def test_lookup(self):
         postcondition = self.initial


### PR DESCRIPTION
This PR adds support for updating either all or only the latest version of a member when type 1 updates are being performed to `SlowlyChangingDimension` to fix issue #64. The updated versions are still being deleted from the cache which probably is not necessary, but since deleting them from the cache should always be safe I have opted for not optimizing the caching until after the code that performs the type 1 updates is done, tested, and reviewed.