### PR TITLE
Fix `MappingSource` duplicating rows when passing multiple callables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Unreleased
   ``dependson`` is now a list instead of a filter iterator. This fixes issue #72 
   where dependencies were only loaded in the first bulk load.
 
+  ``MappingSource`` no longer duplicates rows when passing multiple callables.
+
 **Changed**
   ``SQLSource`` now has a ``fetchsize`` constructor parameter so the end-user can
   control how much data should be held in main memory for each round trip to the RDBMS.

--- a/pygrametl/datasources.py
+++ b/pygrametl/datasources.py
@@ -387,7 +387,7 @@ class MappingSource(object):
         for row in self._source:
             for (att, func) in self._callables.items():
                 row[att] = func(row[att])
-                yield row
+            yield row
 
 
 class TransformingSource(object):

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -26,8 +26,56 @@ import sqlite3
 import unittest
 
 import pygrametl
-from pygrametl.datasources import SQLTransformingSource
+from pygrametl.datasources import MappingSource, SQLTransformingSource
 from tests import utilities
+
+
+class MappingSourceTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Ensure other tests does not affect these tests
+        utilities.remove_default_connection_wrapper()
+
+    def setUp(self):
+        self.input_list = [
+            { "id": 1, "title": "Unknown", "genre": "Unknown" },
+            { "id": 2, "title": "Nineteen Eighty-Four", "genre": "Novel" },
+            { "id": 3, "title": "Calvin and Hobbes One", "genre": "Comic" },
+            { "id": 4, "title": "Calvin and Hobbes Two", "genre": "Comic" },
+            { "id": 5, "title": "The Silver Spoon", "genre": "Cookbook" }
+        ]
+
+    def test_mapping_single_callable(self):
+        source = MappingSource(iter(self.input_list), {
+            "id": lambda x: x + 1
+        })
+        expected = [
+            { "id": 2, "title": "Unknown", "genre": "Unknown" },
+            { "id": 3, "title": "Nineteen Eighty-Four", "genre": "Novel" },
+            { "id": 4, "title": "Calvin and Hobbes One", "genre": "Comic" },
+            { "id": 5, "title": "Calvin and Hobbes Two", "genre": "Comic" },
+            { "id": 6, "title": "The Silver Spoon", "genre": "Cookbook" }
+        ]
+
+        self.assertIsNone(pygrametl.getdefaulttargetconnection())
+        self.assertEqual(expected, list(source))
+
+    def test_mapping_two_callables(self):
+        source = MappingSource(iter(self.input_list), {
+            "id": lambda x: x + 1,
+            "genre": lambda x: x[0]
+        })
+        expected = [
+            { "id": 2, "title": "Unknown", "genre": "U" },
+            { "id": 3, "title": "Nineteen Eighty-Four", "genre": "N" },
+            { "id": 4, "title": "Calvin and Hobbes One", "genre": "C" },
+            { "id": 5, "title": "Calvin and Hobbes Two", "genre": "C" },
+            { "id": 6, "title": "The Silver Spoon", "genre": "C" }
+        ]
+
+
+        self.assertIsNone(pygrametl.getdefaulttargetconnection())
+        self.assertEqual(expected, list(source))
 
 
 class SQLTransformationSourceTest(unittest.TestCase):


### PR DESCRIPTION
Previously, `MappingSource` only behaved as expected when only passing a single callable, as it would yield a new row for each callable.
Now, we instead only yield a row for each row in the original datasource.

I have also added a few tests to verify this behavior