### PR TITLE
Fix fetchsize in SQLSource and add tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
   ``t``, this makes it possible to use ``t[n]`` to get the ``n``th row
   in ``t``.
 
+  ``__len__`` added to ``drawntabletesting.Table``. For a Table ``t``,
+  this makes it possible to use ``len(n)`` to get the number of rows
+  in ``t``.
+
 **Fixed**
   All uses of ``open()`` in the beginner guide now include "utf-8" to minimize
   the chance of errors due to different encodings.

--- a/pygrametl/datasources.py
+++ b/pygrametl/datasources.py
@@ -134,6 +134,7 @@ class SQLSource(object):
         self.names = names
         self.executed = False
         self.parameters = parameters
+        self.fetchsize = fetchsize
 
     def __iter__(self):
         try:
@@ -147,10 +148,10 @@ class SQLSource(object):
                     names = self.names or \
                         [t[0] for t in self.cursor.description]
             while True:
-                if fetchsize <= 0:
+                if self.fetchsize <= 0:
                     data = self.cursor.fetchall()
                 else:
-                    data = self.cursor.fetchmany(fetchsize)
+                    data = self.cursor.fetchmany(self.fetchsize)
 
                 if not data:
                     break
@@ -169,7 +170,7 @@ class SQLSource(object):
 
                 # It is not well defined in PEP 249 what fetchall will do if called twice
                 # Therefore it is safest to break the loop if fetchall is used
-                if fetchsize <= 0:
+                if self.fetchsize <= 0:
                     break
         finally:
             try:

--- a/pygrametl/drawntabletesting/__init__.py
+++ b/pygrametl/drawntabletesting/__init__.py
@@ -147,6 +147,10 @@ class Table:
         """Return a string version of the table in the input format."""
         return self.__table2str(self.__rows, False, indention=0)
 
+    def __len__(self):
+        """Return the number rows in the table."""
+        return len(self.__rows)
+
     def __iter__(self):
         """Return an iterator of the rows as dicts."""
         return map(lambda row: dict(zip(self.__columns, row)), self.__rows)

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -26,8 +26,65 @@ import sqlite3
 import unittest
 
 import pygrametl
-from pygrametl.datasources import MappingSource, SQLTransformingSource
+import pygrametl.drawntabletesting as dtt
+from pygrametl.datasources import SQLSource, MappingSource, SQLTransformingSource
 from tests import utilities
+
+class SQLSourceTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.connection = utilities.get_connection()
+        cls.connection_wrapper = pygrametl.ConnectionWrapper(cls.connection)
+        cls.initial = dtt.Table("book", """
+        | id:int (pk) | title:text            | genre:text |
+        | ----------- | --------------------- | ---------- |
+        | 1           | Unknown               | Unknown    |
+        | 2           | Nineteen Eighty-Four  | Novel      |
+        | 3           | Calvin and Hobbes One | Comic      |
+        | 4           | Calvin and Hobbes Two | Comic      |
+        | 5           | The Silver Spoon      | Cookbook   |
+        """)
+        cls.row_len = len(cls.initial)
+        cls.column_len = len(cls.initial[0].keys())
+        cls.names = list(cls.initial[0].keys())
+        cls.initial.ensure()
+        cls.query = "SELECT * FROM book"
+
+    def assert_all_rows_and_columns_returned(self, sql_source, names):
+        row_counter = 0
+        for row in sql_source:
+            row_counter += 1
+            self.assertEqual(self.column_len, len(row.keys()))
+            self.assertEqual(names, list(row.keys()))
+        self.assertEqual(self.row_len, row_counter)
+
+    def test_with_default_arguments(self):
+        sql_source = SQLSource(self.connection, self.query)
+        self.assert_all_rows_and_columns_returned(sql_source, self.names)
+
+    def test_with_correct_number_of_names(self):
+        names = ["bid", "title", "genre"]
+        sql_source = SQLSource(self.connection, self.query, names=names)
+        self.assert_all_rows_and_columns_returned(sql_source, names)
+
+    def test_with_too_few_names(self):
+        with self.assertRaises(ValueError):
+            sql_source = SQLSource(self.connection, self.query, names=["bid"])
+            self.assert_all_rows_and_columns_returned(sql_source, self.names)
+
+    def test_with_too_many_names(self):
+        with self.assertRaises(ValueError):
+            sql_source = SQLSource(self.connection, self.query, names=["bid", "title", "genre", "publisher"])
+            self.assert_all_rows_and_columns_returned(sql_source, self.names)
+
+    def test_with_succeeding_initsql(self):
+        sql_source = SQLSource(self.connection, self.query, initsql="CREATE TABLE author (name VARCHAR)")
+        self.assert_all_rows_and_columns_returned(sql_source, self.names)
+
+    def test_with_failing_initsql(self):
+        with self.assertRaises(sqlite3.OperationalError):
+            SQLSource(self.connection, self.query, initsql="CREATE TABLE book (bid INTEGER)")
 
 
 class MappingSourceTest(unittest.TestCase):


### PR DESCRIPTION
This PR fixes #84 by adding the necessary `self`s to `SQLSource` and adds tests for `SQLSource`.  No tests were added for `cursorarg`, `parameters`, and `fetchsize` as it was unclear how to test them. Finally, an implementation of `__len__` was added to `drawntabletesting.Table` that match itst existing table of `__iter__` as it did not seem possible to get the number of rows in the drawn table without iterating over the iterator each time.