### PR TITLE
Fix copyright in conf.py to match pygrametl.org

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "pygrametl"
-copyright = "2009 - 2023, Aalborg University"
+copyright = "2009 - 2026, Aalborg University"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This PR fixes the copyright in `conf.py` to match [pygrametl.org/doc/index.html](https://pygrametl.org/doc/index.html).