### PR TITLE
Add UnpivotingSource for reshaping wide rows into long rows

### DIFF
--- a/docs/examples/datasources.rst
+++ b/docs/examples/datasources.rst
@@ -385,3 +385,19 @@ features see :doc:`parallel`.
 
     salesFiles = glob.glob('sales/*.csv')
     combinedSales = DynamicForEachSource(seq=salesFiles, callee=createCSVSource)
+
+UnpivotingSource
+----------------
+Converts wide rows (e.g. monthly columns) into long rows.
+
+.. code-block:: python
+
+    from pygrametl.datasources import UnpivotingSource
+    source = UnpivotingSource(
+        [{"product": "A", "jan": 10, "feb": 12}],
+        keyatts=("product",),
+        unpivotatts=("jan", "feb"),
+        nameatt="month",
+        valueatt="sales"
+    )
+    # → [{"product": "A", "month": "jan", "sales": 10}, ...]

--- a/pygrametl/datasources.py
+++ b/pygrametl/datasources.py
@@ -66,6 +66,7 @@ __all__ = [
     "FilteringSource",
     "DynamicForEachSource",
     "RoundRobinSource",
+    "UnpivotingSource",
 ]
 
 
@@ -779,3 +780,75 @@ class DynamicForEachSource(object):
                     yield row
             except Empty:
                 return
+
+
+class UnpivotingSource(object):
+    """A source that transforms rows from wide to long format."""
+
+    def __init__(
+        self,
+        source,
+        keyatts=(),
+        unpivotatts=None,
+        nameatt="name",
+        valueatt="value",
+        ignorenone=False,
+    ):
+        """Arguments:
+
+        - source: the source to unpivot
+        - keyatts: a sequence of attributes to keep in each created row.
+          Default: ()
+        - unpivotatts: a sequence of attributes to unpivot. If None, all
+          attributes except those in keyatts are unpivoted. Default: None
+        - nameatt: the name of the attribute to store the original column
+          name in. Default: 'name'
+        - valueatt: the name of the attribute to store the original column
+          value in. Default: 'value'
+        - ignorenone: a boolean deciding if attributes with the value None
+          should be skipped. Default: False
+        """
+        self.__source = source
+
+        if type(keyatts) in pygrametl._stringtypes:
+            keyatts = (keyatts,)
+        self.__keyatts = tuple(keyatts)
+
+        if unpivotatts is not None and type(unpivotatts) in pygrametl._stringtypes:
+            unpivotatts = (unpivotatts,)
+        self.__unpivotatts = tuple(unpivotatts) if unpivotatts is not None else None
+
+        self.__nameatt = nameatt
+        self.__valueatt = valueatt
+        self.__ignorenone = ignorenone
+
+        if nameatt == valueatt:
+            raise ValueError("nameatt and valueatt must be different")
+        if nameatt in self.__keyatts or valueatt in self.__keyatts:
+            raise ValueError("nameatt and valueatt must not be among keyatts")
+        if self.__unpivotatts is not None:
+            for att in self.__unpivotatts:
+                if att in self.__keyatts:
+                    raise ValueError(
+                        "unpivotatts must not contain attributes also in keyatts"
+                    )
+
+    def __iter__(self):
+        for row in self.__source:
+            resbase = {}
+            for att in self.__keyatts:
+                resbase[att] = row[att]
+
+            if self.__unpivotatts is None:
+                atts = [att for att in row if att not in self.__keyatts]
+            else:
+                atts = self.__unpivotatts
+
+            for att in atts:
+                value = row[att]
+                if self.__ignorenone and value is None:
+                    continue
+                res = resbase.copy()
+                res[self.__nameatt] = att
+                res[self.__valueatt] = value
+                yield res

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -31,6 +31,7 @@ from pygrametl.datasources import (
     SQLSource,
     MappingSource,
     SQLTransformingSource,
+    UnpivotingSource,
 )
 from tests import utilities
 
@@ -253,3 +254,63 @@ class SQLTransformationSourceTest(unittest.TestCase):
         # Ensure this test does not affect the other tests even if it fails
         utilities.remove_default_connection_wrapper()
         self.assertEqual(self.expected_group_by_genre, list(source))
+
+
+class UnpivotingSourceTest(unittest.TestCase):
+    def test_unpivot_with_explicit_attributes(self):
+        source = UnpivotingSource(
+            [
+                {"product": "A", "jan": 1, "feb": 2},
+                {"product": "B", "jan": 3, "feb": 4},
+            ],
+            keyatts=("product",),
+            unpivotatts=("jan", "feb"),
+            nameatt="month",
+            valueatt="sales",
+        )
+
+        expected = [
+            {"product": "A", "month": "jan", "sales": 1},
+            {"product": "A", "month": "feb", "sales": 2},
+            {"product": "B", "month": "jan", "sales": 3},
+            {"product": "B", "month": "feb", "sales": 4},
+        ]
+        self.assertEqual(expected, list(source))
+
+    def test_unpivot_with_inferred_attributes(self):
+        source = UnpivotingSource(
+            [
+                {"id": 1, "a": 10, "b": 20},
+            ],
+            keyatts="id",
+        )
+
+        expected = [
+            {"id": 1, "name": "a", "value": 10},
+            {"id": 1, "name": "b", "value": 20},
+        ]
+        self.assertEqual(expected, list(source))
+
+    def test_unpivot_ignoring_none(self):
+        source = UnpivotingSource(
+            [
+                {"id": 1, "a": None, "b": 20},
+            ],
+            keyatts="id",
+            ignorenone=True,
+        )
+
+        expected = [
+            {"id": 1, "name": "b", "value": 20},
+        ]
+        self.assertEqual(expected, list(source))
+
+    def test_invalid_arguments(self):
+        with self.assertRaises(ValueError):
+            UnpivotingSource([], keyatts=("id",), nameatt="name", valueatt="name")
+
+        with self.assertRaises(ValueError):
+            UnpivotingSource([], keyatts=("name",), nameatt="name")
+
+        with self.assertRaises(ValueError):
+            UnpivotingSource([], keyatts=("id",), unpivotatts=("id",))


### PR DESCRIPTION
`UnpivotingSource` is a new datasource class for converting **wide rows** into **long rows**. I believe it will fit Pygrametl's existing datasource-oriented API and complements `CrossTabbingSource`.